### PR TITLE
Add Proc Macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,9 +46,6 @@ crossbeam = "0.3"
 libc = { version = "0.2", optional = true }
 uuid = { version = "0.5", features = ["v4"] }
 
-# derive
-actix_derive = { path = "actix_derive", version = "0.1.0" }
-
 [dependencies.tokio-signal]
 version = "0.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ signal = ["tokio-signal", "libc"]
 dns = ["libc"]
 
 [workspace]
-members = ["examples/chat"]
+members = ["examples/chat", "actix_derive"]
 
 [dependencies]
 # tokio
@@ -45,6 +45,9 @@ log = "0.3"
 crossbeam = "0.3"
 libc = { version = "0.2", optional = true }
 uuid = { version = "0.5", features = ["v4"] }
+
+# derive
+actix_derive = { path = "actix_derive", version = "0.1.0" }
 
 [dependencies.tokio-signal]
 version = "0.1"

--- a/actix_derive/Cargo.toml
+++ b/actix_derive/Cargo.toml
@@ -9,3 +9,7 @@ proc-macro = true
 [dependencies]
 quote = "0.3.15"
 syn = { version = "0.11.11", features = ["full"] }
+
+[features]
+nightly = []
+handler = ["nightly"]

--- a/actix_derive/Cargo.toml
+++ b/actix_derive/Cargo.toml
@@ -7,5 +7,5 @@ authors = ["Callym <hi@callym.com>"]
 proc-macro = true
 
 [dependencies]
-quote = "*"
-syn = "*"
+quote = "0.3.15"
+syn = { version = "0.11.11", features = ["full"] }

--- a/actix_derive/Cargo.toml
+++ b/actix_derive/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "actix_derive"
+version = "0.1.0"
+authors = ["Callym <hi@callym.com>"]
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "*"
+syn = "*"

--- a/actix_derive/src/actor.rs
+++ b/actix_derive/src/actor.rs
@@ -1,0 +1,13 @@
+use quote;
+use syn;
+
+pub fn expand(ast: &syn::DeriveInput) -> quote::Tokens {
+    let name = &ast.ident;
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    quote!{
+        impl #impl_generics Actor for #name #ty_generics #where_clause {
+            type Context = Context<Self>;
+        }
+    }
+}

--- a/actix_derive/src/actor.rs
+++ b/actix_derive/src/actor.rs
@@ -11,3 +11,60 @@ pub fn expand(ast: &syn::DeriveInput) -> quote::Tokens {
         }
     }
 }
+
+#[cfg(feature = "handler")]
+pub fn handler(_attribute: &syn::Expr, input: &syn::Item) -> quote::Tokens {
+    let (for_type, impl_items) = match input.node {
+        syn::ItemKind::Impl(_, _, _, _, ref for_type, ref impl_items) => (for_type, impl_items),
+        _ => panic!("#[handler] is only valid on impl blocks"),
+    };
+
+    let mut impls = vec![];
+
+    for item in impl_items.iter() {
+        let name = &item.ident;
+
+        let handle = item.attrs.iter()
+            .filter(|a| a.value.name() == "handle")
+            .collect::<Vec<_>>();
+
+        if handle.len() == 0 {
+            continue;
+        } else if handle.len() > 1 {
+            panic!("Can only have 1 #[handle(...)] attributes on {}, found {}", name.as_ref(), handle.len());
+        }
+
+        let ty = match handle[0].value {
+            syn::MetaItem::List(_, ref ty) => ty,
+            _ => panic!("The correct syntax is #[handle(type)]"),
+        };
+
+        if ty.len() != 1 {
+            panic!("The correct syntax is #[handle(type)]");
+        }
+
+        let ty = ::meta_item_to_ty(&ty[0], "handle")
+            .unwrap();
+
+        match item.node {
+            syn::ImplItemKind::Method(..) => (),
+            _ => panic!("#[handle(type)] is only valid on methods"),
+        };
+
+        impls.push(quote!{
+            impl Handler<#ty> for #for_type {
+                fn handle(&mut self, message: #ty, context: &mut Context<Self>) -> Response<Self, #ty> {
+                    self.#name(message, context)
+                }
+            }
+        });
+    }
+
+    let input = ::remove_attr(input, "handle");
+
+    quote!{
+        #input
+
+        #(#impls)*
+    }
+}

--- a/actix_derive/src/lib.rs
+++ b/actix_derive/src/lib.rs
@@ -41,15 +41,21 @@ fn get_attribute_type(ast: &syn::DeriveInput, name: &str) -> Option<syn::Ty> {
 
     let attr = attr.unwrap();
 
-    if let syn::MetaItem::NameValue(_, ref a) = attr.value {
-        if let syn::Lit::Str(ref value, _) = *a {
-            let ty = syn::parse::ty(value);
-            match ty {
-                syn::parse::IResult::Done(_, ty) => return Some(ty),
-                _ => panic!(""),
+    if let syn::MetaItem::List(_, ref vec) = attr.value {
+        if vec.len() != 1 {
+            panic!();
+        }
+
+        if let syn::NestedMetaItem::MetaItem(ref i) = vec[0] {
+            if let syn::MetaItem::Word(ref i) = *i {
+                let ty = syn::parse::ty(i.as_ref());
+                match ty {
+                    syn::parse::IResult::Done(_, ty) => return Some(ty),
+                    _ => panic!(""),
+                }
             }
         }
     }
 
-    None
+    panic!();
 }

--- a/actix_derive/src/lib.rs
+++ b/actix_derive/src/lib.rs
@@ -1,0 +1,55 @@
+extern crate proc_macro;
+extern crate syn;
+#[macro_use]
+extern crate quote;
+
+use proc_macro::TokenStream;
+
+mod actor;
+mod message;
+
+macro_rules! create_derive(
+    ($mod_: ident, $trait_: ident, $fn_name: ident) => {
+        #[proc_macro_derive($trait_)]
+        #[doc(hidden)]
+        pub fn $fn_name(input: TokenStream) -> TokenStream {
+            let s = input.to_string();
+            let ast = syn::parse_derive_input(&s).unwrap();
+            $mod_::expand(&ast).parse().expect("Expanded output was no correct Rust code")
+        }
+    };
+    ($mod_: ident, $trait_: ident, $fn_name: ident, $($attr: ident),+) => {
+        #[proc_macro_derive($trait_, attributes($($attr),+))]
+        #[doc(hidden)]
+        pub fn $fn_name(input: TokenStream) -> TokenStream {
+            let s = input.to_string();
+            let ast = syn::parse_derive_input(&s).unwrap();
+            $mod_::expand(&ast).parse().expect("Expanded output was no correct Rust code")
+        }
+    };
+);
+
+create_derive!(actor, Actor, actor_derive);
+create_derive!(message, Message, message_derive, MessageResult, MessageError);
+
+fn get_attribute_type(ast: &syn::DeriveInput, name: &str) -> Option<syn::Ty> {
+    let attr = ast.attrs.iter().find(|a| a.name() == name);
+
+    if attr.is_none() {
+        return None;
+    }
+
+    let attr = attr.unwrap();
+
+    if let syn::MetaItem::NameValue(_, ref a) = attr.value {
+        if let syn::Lit::Str(ref value, _) = *a {
+            let ty = syn::parse::ty(value);
+            match ty {
+                syn::parse::IResult::Done(_, ty) => return Some(ty),
+                _ => panic!(""),
+            }
+        }
+    }
+
+    None
+}

--- a/actix_derive/src/lib.rs
+++ b/actix_derive/src/lib.rs
@@ -30,7 +30,27 @@ macro_rules! create_derive(
 );
 
 create_derive!(actor, Actor, actor_derive);
-create_derive!(message, Message, message_derive, MessageResult, MessageError);
+create_derive!(message, Message, message_derive, MessageResult, MessageError, Message);
+
+fn exists_attribute(ast: &syn::DeriveInput, name: &str) -> bool {
+    ast.attrs.iter().find(|a| a.name() == name).is_some()
+}
+
+fn get_attribute_type_multiple(ast: &syn::DeriveInput, name: &str) -> Option<Vec<Option<syn::Ty>>> {
+    let attr = ast.attrs.iter().find(|a| a.name() == name);
+
+    if attr.is_none() {
+        return None;
+    }
+
+    let attr = attr.unwrap();
+
+    if let syn::MetaItem::List(_, ref vec) = attr.value {
+        Some(vec.iter().map(|m| meta_item_to_ty(m, name)).collect())
+    } else {
+        panic!("The correct syntax is #[{}(type, type, ...)]", name);
+    }
+}
 
 fn get_attribute_type(ast: &syn::DeriveInput, name: &str) -> Option<syn::Ty> {
     let attr = ast.attrs.iter().find(|a| a.name() == name);
@@ -43,19 +63,23 @@ fn get_attribute_type(ast: &syn::DeriveInput, name: &str) -> Option<syn::Ty> {
 
     if let syn::MetaItem::List(_, ref vec) = attr.value {
         if vec.len() != 1 {
-            panic!();
+            panic!("#[{}(type)] takes 1 parameter, given {}", name, vec.len());
         }
 
-        if let syn::NestedMetaItem::MetaItem(ref i) = vec[0] {
-            if let syn::MetaItem::Word(ref i) = *i {
-                let ty = syn::parse::ty(i.as_ref());
-                match ty {
-                    syn::parse::IResult::Done(_, ty) => return Some(ty),
-                    _ => panic!(""),
-                }
-            }
-        }
+        meta_item_to_ty(&vec[0], name)
+    } else {
+        panic!("The correct syntax is #[{}(type)]", name);
     }
+}
 
-    panic!();
+fn meta_item_to_ty(meta_item: &syn::NestedMetaItem, name: &str) -> Option<syn::Ty> {
+    if let syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref i)) = *meta_item {
+        let ty = syn::parse::ty(i.as_ref());
+        match ty {
+            syn::parse::IResult::Done(_, ty) => Some(ty),
+            _ => None,
+        }
+    } else {
+        panic!("The correct syntax is #[{}(type)]", name);
+    }
 }

--- a/actix_derive/src/message.rs
+++ b/actix_derive/src/message.rs
@@ -3,21 +3,41 @@ use syn;
 
 pub const RESULT_TYPE: &str = "MessageResult";
 pub const ERROR_TYPE: &str = "MessageError";
+pub const COMBINED_TYPE: &str = "Message";
 
 pub fn expand(ast: &syn::DeriveInput) -> quote::Tokens {
+    if ::exists_attribute(ast, COMBINED_TYPE) && ::exists_attribute(ast, RESULT_TYPE) {
+        panic!("Cannot use #[{}] and #[{}] on the same type", COMBINED_TYPE, RESULT_TYPE);
+    }
+
+    if ::exists_attribute(ast, COMBINED_TYPE) && ::exists_attribute(ast, ERROR_TYPE) {
+        panic!("Cannot use #[{}] and #[{}] on the same type", COMBINED_TYPE, ERROR_TYPE);
+    }
+
+    let (item_type, error_type) = {
+        if let Some(ty) = ::get_attribute_type_multiple(ast, COMBINED_TYPE) {
+            match ty.len() {
+                1 => (ty[0].clone(), None),
+                2 => (ty[0].clone(), ty[1].clone()),
+                _ => panic!("#[{}(type, type)] takes 2 parameters, given {}", COMBINED_TYPE, ty.len()),
+            }
+        } else {
+            let item_type = ::get_attribute_type(ast, RESULT_TYPE);
+            let error_type = ::get_attribute_type(ast, ERROR_TYPE);
+            (item_type, error_type)
+        }
+    };
+
     let name = &ast.ident;
-	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
 
-	let item_type = ::get_attribute_type(ast, RESULT_TYPE)
-		.unwrap_or(syn::Ty::Tup(vec![]));
-
-	let error_type = ::get_attribute_type(ast, ERROR_TYPE)
-		.unwrap_or(syn::Ty::Tup(vec![]));
+    let item_type = item_type.unwrap_or(syn::Ty::Tup(vec![]));
+    let error_type = error_type.unwrap_or(syn::Ty::Tup(vec![]));
 
     quote!{
         impl #impl_generics ResponseType for #name #ty_generics #where_clause {
             type Item = #item_type;
-			type Error = #error_type;
+            type Error = #error_type;
         }
     }
 }

--- a/actix_derive/src/message.rs
+++ b/actix_derive/src/message.rs
@@ -1,0 +1,23 @@
+use quote;
+use syn;
+
+pub const RESULT_TYPE: &str = "MessageResult";
+pub const ERROR_TYPE: &str = "MessageError";
+
+pub fn expand(ast: &syn::DeriveInput) -> quote::Tokens {
+    let name = &ast.ident;
+	let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+	let item_type = ::get_attribute_type(ast, RESULT_TYPE)
+		.unwrap_or(syn::Ty::Tup(vec![]));
+
+	let error_type = ::get_attribute_type(ast, ERROR_TYPE)
+		.unwrap_or(syn::Ty::Tup(vec![]));
+
+    quote!{
+        impl #impl_generics ResponseType for #name #ty_generics #where_clause {
+            type Item = #item_type;
+			type Error = #error_type;
+        }
+    }
+}


### PR DESCRIPTION
Adds support for the following custom derives, as discussed in #13 
- `[derive(Message)]`
    - `#[MessageResult(type)]`
    - `#[MessageError(type)]`
    - `#[Message(result_type, error_type)]` (where `error_type` is optional)
```rust
#[derive(Message)]
#[MessageResult(usize)]
struct Sum(usize, usize);

#[derive(Actor)]
struct SumActor;
```

Which expands to:
```rust
impl ResponseType for Sum {
    type Item = usize;
    type Error = ();
}

impl Actor for SumActor {
    type Context = Context<Self>;
}
```

Adds support for a `#[handler]` macro when used with the `handler` feature. (Requires the `proc_macro` feature and therefore nightly)
```rust
#![feature(proc_macro)]

#[handler]
impl SumActor {
    #[handle(Sum)]
    fn sum(&mut self, message: Sum, _: &mut Context<Self>) -> Response<Self, Sum> {
        println!("{}", message.0 + message.1);
        Self::reply(message.0 + message.1)
    }
}
```

Which expands to:
```rust
#![feature(proc_macro)]

impl SumActor {
    fn sum(&mut self, message: Sum, _: &mut Context<Self>) -> Response<Self, Sum> {
        println!("{}", message.0 + message.1);
        Self::reply(message.0 + message.1)
    }
}

impl Handler<Sum> for SumActor {
    fn handle(&mut self, message: Sum, context: &mut Context<Self>) -> Response<Self, Sum> {
        self.sum(message, context)
    }
}
```