### PR TITLE
Allow returning Box<ActorFuture> in ActorFutures

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,9 @@
 # CHANGES
 
+## Master
+
+* Allow returning Box<ActorFuture> in ActorFutures for non tail recursive futures
+
 ## 0.3.2 (2017-11-06)
 
 * Disable `signal` feature by default

--- a/src/fut/mod.rs
+++ b/src/fut/mod.rs
@@ -189,6 +189,20 @@ impl<F: ActorFuture> IntoActorFuture for F {
     }
 }
 
+impl<F: ActorFuture + ?Sized> ActorFuture for Box<F> {
+    type Item = F::Item;
+    type Error = F::Error;
+    type Actor = F::Actor;
+
+
+    fn poll(&mut self, srv: &mut Self::Actor, ctx: &mut <Self::Actor as Actor>::Context)
+            -> Poll<Self::Item, Self::Error> {
+        {
+            (**self).poll(srv, ctx)
+        }
+    }
+}
+
 /// Helper trait that allows conversion of normal future into `ActorFuture`
 pub trait WrapFuture<A> where A: Actor
 {


### PR DESCRIPTION
This allows for non tail recursive futures, such as [here](https://github.com/kingoflolz/routing-actor/blob/master/src/dht/service.rs#L100)