### PR TITLE
Message link was pointing to Actor trait

### DIFF
--- a/guide/src/qs_03.md
+++ b/guide/src/qs_03.md
@@ -67,7 +67,7 @@ to `Stopped`. This state is considered final and at this point actor get dropped
 
 An Actor communicates with another Actors by sending messages. In actix all
 messages are typed. Message could be any rust type which implements
-[Message](../actix/trait.Actor.html) trait. *Message::Result* defines return type.
+[Message](../actix/trait.Message.html) trait. *Message::Result* defines return type.
 Let's define a simple `Ping` message, an actor which will accept this message needs to return
 `io::Result<bool>`.
 


### PR DESCRIPTION
The link to the Message trait was pointed towards the Actor trait, changed to point towards the Message trait.