### PR TITLE
Fix index usage during iteration for future cancellation

### DIFF
--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -236,9 +236,12 @@ impl<A> ContextImpl<A> where A: Actor, A::Context: AsyncContext<A>
             // check cancelled handles, just in case
             while self.handles.len() > 2 {
                 let handle = self.handles.pop().unwrap();
-                for idx in 0..self.items.len() {
+                let mut idx = 0;
+                while idx < self.items.len() {
                     if self.items[idx].0 == handle {
                         self.items.swap_remove(idx);
+                    } else {
+                        idx += 1;
                     }
                 }
             }
@@ -280,9 +283,12 @@ impl<A> ContextImpl<A> where A: Actor, A::Context: AsyncContext<A>
                             // in actor context should be small
                             while self.handles.len() > 2 {
                                 let handle = self.handles.pop().unwrap();
-                                for idx in 0..self.items.len() {
+                                let mut idx = 0;
+                                while idx < self.items.len() {
                                     if self.items[idx].0 == handle {
                                         self.items.swap_remove(idx);
+                                    } else {
+                                        idx += 1;
                                     }
                                 }
                             }

--- a/tests/test_context.rs
+++ b/tests/test_context.rs
@@ -30,8 +30,10 @@ impl Actor for MyActor {
     fn started(&mut self, ctx: &mut Context<MyActor>) {
         match self.op {
             Op::Cancel => {
-                let handle = ctx.notify_later(TimeoutMessage, Duration::new(0, 100));
-                ctx.cancel_future(handle);
+                let handle0 = ctx.notify_later(TimeoutMessage, Duration::new(0, 100));
+                let handle1 = ctx.notify_later(TimeoutMessage, Duration::new(0, 100));
+                assert!(ctx.cancel_future(handle1));
+                assert!(ctx.cancel_future(handle0));
             },
             Op::Timeout => {
                 ctx.notify_later(TimeoutMessage, Duration::new(0, 1000));


### PR DESCRIPTION
The iteration range is calculated once before starting the loop. During
the iterations the container might change it's size and the index access
fails. This patch is a minimal invasive modification fix in order to
keep the index access style used in `ContextImpl`.

Fixes #66.