### PR TITLE
Add mocker actor and registry start function

### DIFF
--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -1,0 +1,95 @@
+extern crate actix;
+extern crate futures;
+
+use futures::Future;
+use actix::prelude::*;
+use actix::actors::mocker::Mocker;
+
+#[derive(Eq, PartialEq, Debug)]
+struct DoStuff{}
+
+impl Message for DoStuff {
+    type Result = String;
+}
+
+/// An example an actor which you would not like to actually run in a test
+struct DBClientActor {}
+
+impl Actor for DBClientActor {
+    type Context = Context<Self>;
+}
+
+/// Nothing special needs to be done here
+impl Handler<DoStuff> for DBClientActor {
+    type Result = String;
+
+    fn handle(&mut self, msg: DoStuff, _: &mut Context<Self>) -> Self::Result {
+        // do normal database stuff here
+        "Reply from database".to_string()
+    }
+}
+
+/// Required for SystemService
+impl Supervised for DBClientActor {}
+impl Default for DBClientActor {
+    fn default() -> Self {
+        DBClientActor{}
+    }
+}
+
+/// Using a SystemService allows the mocker to be injected into the entire application
+impl SystemService for DBClientActor {
+    fn service_started(&mut self, _ctx: &mut Context<Self>) {}
+}
+
+/// This wraps the type you wish to test with Mocker<T> which allows you to mock it, but only when
+/// you are testing
+#[cfg(not(test))]
+type DBClientAct = DBClientActor;
+#[cfg(test)]
+type DBClientAct = Mocker<DBClientActor>;
+
+
+/// This is an example of a function you would like to test that calls external actors which would
+/// be hard to test otherwise
+fn example_function() {
+    let res = DBClientAct::from_registry().send(DoStuff{});
+
+    Arbiter::handle().spawn(
+        res.map(|res| {
+            println!("got reply {}", res);
+            Arbiter::system().do_send(actix::msgs::SystemExit(0));
+        }).map_err(|_| ()));
+}
+
+fn main() {
+    let system = System::new("test");
+
+    // call it normally
+    example_function();
+
+    system.run();
+}
+
+#[test]
+fn test_stuff() {
+    let system = System::new("test");
+
+    // here we setup the mocking
+    let _: Addr<Syn, _> = DBClientAct::init_actor(|_| {
+        DBClientAct::mock(Box::new(|msg, ctx| {
+            // asserting the input to the actor is as expected
+            assert_eq!(
+                msg.downcast_ref::<DoStuff>(),
+                Some(&DoStuff{})
+            );
+
+            // replying
+            Box::new(Some("Reply from mocker".to_string()))
+        }))
+    });
+
+    example_function();
+
+    system.run();
+}

--- a/src/actors/mocker.rs
+++ b/src/actors/mocker.rs
@@ -1,0 +1,70 @@
+//! Mocking utility actor
+//! This actor wraps any actor, and replaces instances of that actor with mocker actor, which is
+//! able to accept all messages which the actor can recieve.
+//!
+//! Mocking is intended to be achieved by using a pattern similar to
+//! ```rust,ignore
+//! #[cfg(not(test))]
+//! type DBClientAct = DBClientActor;
+//! #[cfg(test)]
+//! type DBClientAct = Mocker<DBClientActor>;
+//! ```
+//! Then, the actor should be used as a System Service (or Arbiter Service, but take care that all
+//! the places which will use the mocked actor is on the same arbiter). Thus, in a test, it will
+//! retrieve the mocker from the registry instead of the actual actor.
+//!
+//! To set the mock function in the actor, the init_actor function is used, which allows the state
+//! of an actor to be set when it is started as a arbiter or system service. A closure which takes
+//! Box<Any> is evaluated for every message, and must return Box<Any>, specifically the return type
+//! for the message type send.
+//!
+//! See the mock example to see how it can be used.
+
+use std::marker::PhantomData;
+use std::any::Any;
+use std::mem;
+
+use prelude::*;
+use handler::MessageResponse;
+
+/// This actor is able to wrap another actor and accept all the messages the wrapped actor can,
+/// passing it to a closure which can mock the response of the actors
+pub struct Mocker<T: Sized + 'static>{
+    phantom: PhantomData<T>,
+    mock: Box<FnMut(Box<Any>, &mut Context<Mocker<T>>) -> Box<Any>>
+}
+
+impl<T> Mocker<T> {
+    pub fn mock(mock: Box<FnMut(Box<Any>, &mut Context<Mocker<T>>) -> Box<Any>>) -> Mocker<T> {
+        Mocker::<T> {
+            phantom: PhantomData,
+            mock
+        }
+    }
+}
+
+impl<T: SystemService> actix::SystemService for Mocker<T> {}
+impl<T: ArbiterService> actix::ArbiterService for Mocker<T> {}
+impl<T> Supervised for Mocker<T> {}
+
+impl<T> Default for Mocker<T> {
+    fn default() -> Self {
+        panic!("Mocker actor used before set")
+    }
+}
+
+impl<T: Sized + 'static> Actor for Mocker<T> {
+    type Context = Context<Self>;
+}
+
+impl<M: 'static, T: Sized + 'static> Handler<M> for Mocker<T> where M: Message, <M as actix::Message>::Result: MessageResponse<Mocker<T>, M> {
+    type Result = M::Result;
+    fn handle(&mut self, msg: M, ctx: &mut Self::Context) -> M::Result {
+        let mut ret = (self.mock)(Box::new(msg), ctx);
+        let out = mem::replace(ret.downcast_mut::<Option<M::Result>>().expect("wrong return type for message"), None);
+        match out {
+            Some(a) => return a,
+            _ => panic!()
+        }
+    }
+}

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -2,5 +2,6 @@
 
 mod resolver;
 pub mod signal;
+pub mod mocker;
 
 pub use self::resolver::{Connect, ConnectAddr, Resolve, Connector, ConnectorError};

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -52,7 +52,7 @@ use tokio_core::net::{TcpStream, TcpStreamNew};
 
 use prelude::*;
 
-
+#[derive(Eq, PartialEq, Debug)]
 pub struct Resolve {
     name: String,
     port: Option<u16>,
@@ -73,6 +73,7 @@ impl Message for Resolve {
     type Result = Result<VecDeque<SocketAddr>, ConnectorError>;
 }
 
+#[derive(Eq, PartialEq, Debug)]
 pub struct Connect {
     name: String,
     port: Option<u16>,
@@ -106,6 +107,7 @@ impl Message for Connect {
     type Result = Result<TcpStream, ConnectorError>;
 }
 
+#[derive(Eq, PartialEq, Debug)]
 pub struct ConnectAddr(pub SocketAddr);
 
 impl Message for ConnectAddr {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -95,6 +95,11 @@ pub trait ArbiterService: Actor<Context=Context<Self>> + Supervised + Default {
     fn from_registry() -> Addr<Unsync, Self> {
         Arbiter::registry().get::<Self>()
     }
+
+    /// Create an actor in the Arbiter with a closure
+    fn init_actor<F>(f: F) -> Addr<Unsync, Self> where F: FnOnce(&mut Self::Context) -> Self + 'static{
+        Arbiter::registry().init_actor::<Self, F>(f)
+    }
 }
 
 /// Trait defines system's service.
@@ -107,6 +112,11 @@ pub trait SystemService: Actor<Context=Context<Self>> + Supervised + Default {
     /// Get actor's address from system registry
     fn from_registry() -> Addr<Syn, Self> {
         Arbiter::system_registry().get::<Self>()
+    }
+
+    /// Create an SystemService with a closure
+    fn init_actor<F>(f: F) -> Addr<Syn, Self> where F: FnOnce(&mut Self::Context) -> Self + Send + 'static{
+        Arbiter::system_registry().init_actor::<Self, F>(f)
     }
 }
 
@@ -128,6 +138,25 @@ impl Registry {
         }
         let addr: Addr<Unsync, A> = Supervisor::start(|ctx| {
             let mut act = A::default();
+            act.service_started(ctx);
+            act
+        });
+
+        self.registry.borrow_mut().insert(id, Box::new(addr.clone()));
+        addr
+    }
+
+    /// Add new actor to the registry using the initialization function provided, panic if actor
+    /// is already running
+    pub fn init_actor<A: ArbiterService + Actor<Context=Context<A>>, F>(&self, with: F) -> Addr<Unsync, A> where F: FnOnce(&mut A::Context) -> A + 'static {
+        let id = TypeId::of::<A>();
+        if let Some(addr) = self.registry.borrow().get(&id) {
+            if let Some(addr) = addr.downcast_ref::<Addr<Unsync, A>>() {
+                return addr.clone()
+            }
+        }
+        let addr: Addr<Unsync, A> = Supervisor::start(|ctx| {
+            let mut act = with(ctx);
             act.service_started(ctx);
             act
         });
@@ -171,6 +200,33 @@ impl SystemRegistry {
 
         let addr = Supervisor::start_in(&Arbiter::system_arbiter(), |ctx| {
             let mut act = A::default();
+            act.service_started(ctx);
+            act
+        });
+        if let Ok(mut hm) = self.registry.lock() {
+            hm.insert(TypeId::of::<A>(), Box::new(addr.clone()));
+            return addr
+        }
+        panic!("System registry lock is poisoned");
+    }
+
+    /// Initialize a SystemService, panic if already started
+    pub fn init_actor<A: SystemService + Actor<Context=Context<A>>, F>(&self, with: F) -> Addr<Syn,A> where F: FnOnce(&mut A::Context) -> A + Send + 'static {
+        {
+            if let Ok(hm) = self.registry.lock() {
+                if let Some(addr) = hm.get(&TypeId::of::<A>()) {
+                    match addr.downcast_ref::<Addr<Syn, A>>() {
+                        Some(_) => {
+                            panic!("Actor already started")
+                        },
+                        None => error!("Got unknown value: {:?}", addr),
+                    }
+                }
+            } else { panic!("System registry lock is poisoned"); }
+        }
+
+        let addr = Supervisor::start_in(&Arbiter::system_arbiter(), |ctx| {
+            let mut act = with(ctx);
             act.service_started(ctx);
             act
         });


### PR DESCRIPTION
This PR allows SystemServices and ArbiterServices to be mocked for tests. docs and stuff will be added soon.

You can do something like:
```
// in global scope
#[cfg(test)]
type HTTPClient = Mocker<rita_common::http_client::HTTPClient>;

#[cfg(not(test))]
type HTTPClient = rita_common::http_client::HTTPClient;

// in a test
        let _: Addr<Syn, _> = HTTPClient::start_reg(|_| { HTTPClient::mock(Box::new(|msg, ctx| {
            assert_eq!(msg.downcast_ref::<Hello>(), Some(&Hello{
                my_id: LocalIdentity {
                    wg_port: 60000,
                    global: SETTING.get_identity()
                },
                to: SocketAddr::V4(SocketAddrV4::new("1.1.1.1".parse().unwrap(), 4876))
            }));

            let ret: Result<LocalIdentity, Error> = Ok(LocalIdentity{
                wg_port: 60000,
                global: SETTING.get_identity(),
            });
            Box::new(Some(ret))
        }))});

       // now calls to HTTPClient::from_registry() will return the mocked actor, who's behavior you can control!
```
I'll write some documentation, tests and examples soon, let me know anything you want me to fix up or change!