### PR TITLE
Add MessageResponse section to Chapter 3 with example

### DIFF
--- a/guide/src/qs_03.md
+++ b/guide/src/qs_03.md
@@ -162,3 +162,124 @@ fn main() {
     sys.run();
 }
 ```
+
+## Responding with a MessageResponse
+
+Let's take a look at the `Result` type defined for the `impl Handler` in the above example. See how we're returning a `Result<bool, io::Error>`? We're able to respond to our actor's incoming message with this type because it has the `MessageResponse` trait implemented for that type. Here's the definition:
+
+```rust
+pub trait MessageResponse<A: Actor, M: Message> {
+    fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>);
+}
+```
+
+Sometimes it makes sense to respond to incoming messages with types that don't have this trait implemented for them. When that happens we can implement the trait ourselves. Here's an example where we're responding to a `Ping` message with a `GotPing`, and responding with `GotPong` for a `Pong` message.
+
+```rust
+# extern crate actix;
+# extern crate futures;
+use actix::dev::{MessageResponse, ResponseChannel};
+use actix::prelude::*;
+use futures::Future;
+
+enum Messages {
+    Ping,
+    Pong,
+}
+
+enum Responses {
+    GotPing,
+    GotPong,
+}
+
+impl<A, M> MessageResponse<A, M> for Responses
+where
+    A: Actor,
+    M: Message<Result = Responses>,
+{
+    fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
+        if let Some(tx) = tx {
+            tx.send(self);
+        }
+    }
+}
+
+impl Message for Messages {
+    type Result = Responses;
+}
+
+// Define actor
+struct MyActor;
+
+// Provide Actor implementation for our actor
+impl Actor for MyActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Context<Self>) {
+        println!("Actor is alive");
+    }
+
+    fn stopped(&mut self, ctx: &mut Context<Self>) {
+        println!("Actor is stopped");
+    }
+}
+
+/// Define handler for `Messages` enum
+impl Handler<Messages> for MyActor {
+    type Result = Responses;
+
+    fn handle(&mut self, msg: Messages, ctx: &mut Context<Self>) -> Self::Result {
+        match msg {
+            Messages::Ping => Responses::GotPing,
+            Messages::Pong => Responses::GotPong,
+        }
+    }
+}
+
+fn main() {
+    let sys = System::new("example");
+
+    // Start MyActor in current thread
+    let addr: Addr<Unsync, _> = MyActor.start();
+
+    // Send Ping message.
+    // send() message returns Future object, that resolves to message result
+    let ping_future = addr.send(Messages::Ping);
+    let pong_future = addr.send(Messages::Pong);
+
+    // Get handle to Arbiter's reactor
+    let handle = Arbiter::handle();
+
+    // Spawn pong_future onto event loop
+    handle.spawn(
+        pong_future
+            .map(|res| {
+                match res {
+                    Responses::GotPing => println!("Ping received"),
+                    Responses::GotPong => println!("Pong received"),
+                }
+                Arbiter::system().do_send(actix::msgs::SystemExit(0));
+            })
+            .map_err(|e| {
+                println!("Actor is probably died: {}", e);
+            }),
+    );
+
+    // Spawn ping_future onto event loop
+    handle.spawn(
+        ping_future
+            .map(|res| {
+                match res {
+                    Responses::GotPing => println!("Ping received"),
+                    Responses::GotPong => println!("Pong received"),
+                }
+                Arbiter::system().do_send(actix::msgs::SystemExit(0));
+            })
+            .map_err(|e| {
+                println!("Actor is probably died: {}", e);
+            }),
+    );
+
+    sys.run();
+}
+```


### PR DESCRIPTION
Added a section about responding to messages with custom types by implementing MessageResponse. Let me know if I can change things up to make it more concise. Also, I don't think I should be calling `Arbiter::system().do_send(actix::msgs::SystemExit(0));` in both futures, so let me know what I should do there to make it more correct.