### PR TITLE
Add run_until_complete to run single future

### DIFF
--- a/tests/test_fut.rs
+++ b/tests/test_fut.rs
@@ -93,3 +93,10 @@ fn test_stream_timeout() {
 
     assert!(timeout.load(Ordering::Relaxed), "Not timeout");
 }
+
+#[test]
+fn test_run_until() {
+    let result: Result<&str, ()> = System::run_until_complete(futures::future::ok("result"));
+    let result = result.expect("Ok result");
+    assert_eq!(result, "result");
+}


### PR DESCRIPTION
I'd like to return option to run single future without a need for manual stopping