### PR TITLE
Addr should Arc maybe_park and add tests for capacity

### DIFF
--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -43,7 +43,7 @@ pub struct AddressSender<A: Actor> {
 
     // True if the sender might be blocked. This is an optimization to avoid
     // having to lock the mutex most of the time.
-    maybe_parked: AtomicBool,
+    maybe_parked: Arc<AtomicBool>,
 }
 
 trait AssertKinds: Send + Sync + Clone {}
@@ -171,7 +171,7 @@ pub fn channel<A: Actor>(buffer: usize) -> (AddressSender<A>, AddressReceiver<A>
     let tx = AddressSender {
         inner: Arc::clone(&inner),
         sender_task: Arc::new(Mutex::new(SenderTask::new())),
-        maybe_parked: AtomicBool::new(false),
+        maybe_parked: Arc::new(AtomicBool::new(false)),
     };
 
     let rx = AddressReceiver { inner };
@@ -469,7 +469,7 @@ impl<A: Actor> Clone for AddressSender<A> {
                 return AddressSender {
                     inner: Arc::clone(&self.inner),
                     sender_task: Arc::new(Mutex::new(SenderTask::new())),
-                    maybe_parked: AtomicBool::new(false),
+                    maybe_parked: Arc::new(AtomicBool::new(false)),
                 };
             }
 
@@ -552,7 +552,7 @@ impl<A: Actor> AddressReceiver<A> {
                 return AddressSender {
                     inner: Arc::clone(&self.inner),
                     sender_task: Arc::new(Mutex::new(SenderTask::new())),
-                    maybe_parked: AtomicBool::new(false),
+                    maybe_parked: Arc::new(AtomicBool::new(false)),
                 };
             }
 

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -42,6 +42,11 @@ where
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn rx_is_some(&self) -> bool {
+        self.rx.is_some()
+    }
+
     /// Set message delivery timeout
     pub fn timeout(mut self, dur: Duration) -> Self {
         self.timeout = Some(Delay::new(Instant::now() + dur));


### PR DESCRIPTION
I think `maybe_park` should in Arc as Atomic is just Cell by itself, with Arc all cloned addrs should get the same `maybe_parked`

In addition to that I added test case to verify that addr sender gets full.

Note that it seems that `Actor::started` gets called only on initial send gets spawned, so current test is kinda work around of this limitation.