### PR TITLE
Arbiter: optionally stop system if Actor/Arbiter panics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # CHANGES
 
+## [0.7.1] (2018-07-xx)
+
+### Added
+
+* Arbiter now has `Arbiter::builder()` which allows opt-in of behavior to stop
+  the actor system on uncaught panic in any arbiter thread. See #111 for examples.
+
 ## [0.7.0] (2018-07-05)
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actor framework for Rust"
 readme = "README.md"

--- a/src/arbiter.rs
+++ b/src/arbiter.rs
@@ -30,22 +30,55 @@ thread_local!(
 /// Arbiter controls event loop in it's thread. Each arbiter runs in separate
 /// thread. Arbiter provides several api for event loop access. Each arbiter
 /// can belongs to specific `System` actor.
+///
+/// By default, a panic in an Arbiter does _not_ stop the rest of the System,
+/// unless the panic is in the System actor. Users of Arbiter can opt into
+/// shutting down the system on panic by using `Arbiter::builder()` and enabling
+/// `stop_system_on_panic`.
 pub struct Arbiter {
     stop: Option<Sender<i32>>,
+    stop_system_on_panic: bool,
 }
 
 impl Actor for Arbiter {
     type Context = Context<Self>;
 }
 
+impl Drop for Arbiter {
+    fn drop(&mut self) {
+        if self.stop_system_on_panic && thread::panicking() {
+            eprintln!("Panic in Arbiter thread, shutting down system.");
+            System::current().stop_with_code(1)
+        }
+    }
+}
+
 impl Arbiter {
     /// Spawn new thread and run event loop in spawned thread.
     /// Returns address of newly created arbiter.
+    /// Does not stop the system on panic.
+    pub fn builder() -> Builder {
+        Builder::new()
+    }
+
+    /// Spawn new thread and run event loop in spawned thread.
+    /// Returns address of newly created arbiter.
+    /// Does not stop the system on panic.
     pub fn new<T: Into<String>>(name: T) -> Addr<Arbiter> {
+        Arbiter::new_with_builder(Arbiter::builder().name(name))
+    }
+
+    /// Spawn new thread and run event loop in spawned thread.
+    /// Returns address of newly created arbiter.
+    fn new_with_builder(builder: Builder) -> Addr<Arbiter> {
         let (tx, rx) = std::sync::mpsc::channel();
 
         let id = Uuid::new_v4();
-        let name = format!("arbiter:{}:{}", id.hyphenated().to_string(), name.into());
+        let name = format!(
+            "arbiter:{}:{}",
+            id.hyphenated().to_string(),
+            builder.name.as_ref().unwrap_or(&"actor".into())
+        );
         let sys = System::current();
 
         let _ = thread::Builder::new().name(name.clone()).spawn(move || {
@@ -61,7 +94,10 @@ impl Arbiter {
             // start arbiter
             let addr =
                 rt.block_on(future::lazy(move || {
-                    let addr = Actor::start(Arbiter { stop: Some(stop) });
+                    let addr = Actor::start(Arbiter {
+                        stop: Some(stop),
+                        stop_system_on_panic: builder.stop_system_on_panic,
+                    });
                     Ok::<_, ()>(addr)
                 })).unwrap();
             ADDR.with(|cell| *cell.borrow_mut() = Some(addr.clone()));
@@ -97,7 +133,10 @@ impl Arbiter {
 
         // start arbiter
         let ctx = Context::with_receiver(rx);
-        let fut = ctx.into_future(Arbiter { stop: None });
+        let fut = ctx.into_future(Arbiter {
+            stop: None,
+            stop_system_on_panic: true, // If the system Arbiter panics, stop the system.
+        });
         let addr = fut.address();
         Arbiter::spawn(fut);
         ADDR.with(|cell| *cell.borrow_mut() = Some(addr.clone()));
@@ -167,14 +206,22 @@ impl Arbiter {
     /// Start new arbiter and then start actor in created arbiter.
     /// Returns `Addr<Syn, A>` of created actor.
     pub fn start<A, F>(f: F) -> Addr<A>
-    where
-        A: Actor<Context = Context<A>>,
-        F: FnOnce(&mut A::Context) -> A + Send + 'static,
+        where
+            A: Actor<Context = Context<A>>,
+            F: FnOnce(&mut A::Context) -> A + Send + 'static,
+    {
+        Arbiter::builder().start(f)
+    }
+
+    fn start_with_builder<A, F>(builder: Builder, f: F) -> Addr<A>
+        where
+            A: Actor<Context = Context<A>>,
+            F: FnOnce(&mut A::Context) -> A + Send + 'static,
     {
         let (stx, srx) = channel::channel(DEFAULT_CAPACITY);
 
         // new arbiter
-        let addr = Arbiter::new("actor");
+        let addr = Arbiter::new_with_builder(builder);
 
         // create actor
         addr.do_send::<Execute>(Execute::new(move || {
@@ -215,5 +262,54 @@ impl<I: Send, E: Send> Handler<Execute<I, E>> for Arbiter {
 
     fn handle(&mut self, msg: Execute<I, E>, _: &mut Context<Self>) -> Result<I, E> {
         msg.exec()
+    }
+}
+
+/// Builder struct for an Arbiter.
+pub struct Builder {
+    /// Name of the Arbiter. Defaults to "actor" if unset.
+    name: Option<String>,
+
+    /// Whether the Arbiter will stop the whole System on uncaught panic. Defaults to false.
+    stop_system_on_panic: bool,
+}
+
+impl Builder {
+    fn new() -> Self {
+        Builder {
+            name: None,
+            stop_system_on_panic: false,
+        }
+    }
+
+    /// Sets the name of the Arbiter.
+    pub fn name<T: Into<String>>(mut self, name: T) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Sets the option 'stop_system_on_panic' which controls whether the System is stopped when an
+    /// uncaught panic is thrown from an Actor in the Arbiter.
+    ///
+    /// Defaults to false.
+    pub fn stop_system_on_panic(mut self, stop_system_on_panic: bool) -> Self {
+        self.stop_system_on_panic = stop_system_on_panic;
+        self
+    }
+
+    /// Spawn new thread and run event loop in spawned thread.
+    /// Returns address of newly created arbiter.
+    pub fn build(self) -> Addr<Arbiter> {
+        Arbiter::new_with_builder(self)
+    }
+
+    /// Start new arbiter and then start actor in created arbiter.
+    /// Returns `Addr<Syn, A>` of created actor.
+    pub fn start<A, F>(self, f: F) -> Addr<A>
+        where
+            A: Actor<Context = Context<A>>,
+            F: FnOnce(&mut A::Context) -> A + Send + 'static,
+    {
+        Arbiter::start_with_builder(self, f)
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -109,7 +109,12 @@ impl System {
 
     /// Stop the system
     pub fn stop(&self) {
-        self.sys.do_send(SystemExit(0));
+        self.stop_with_code(0)
+    }
+
+    /// Stop the system with a particular exit code.
+    pub(crate) fn stop_with_code(&self, code: i32) {
+        self.sys.do_send(SystemExit(code));
     }
 
     pub(crate) fn sys(&self) -> &Addr<SystemArbiter> {
@@ -183,7 +188,7 @@ pub struct SystemRunner {
 
 impl SystemRunner {
     /// This function will start event loop and will finish once the
-    /// `System::stop()` function get called.
+    /// `System::stop()` function is called.
     pub fn run(self) -> i32 {
         let SystemRunner { mut rt, stop, .. } = self;
 


### PR DESCRIPTION
When an Actor panics in an Arbiter, the Arbiter thread stops but no
other action is taken, the rest of the program continues to run. Only if
a sender is using try_send or send will they notice the failure. This
can lead to surprising circumstances where a program will appear to be
running but instead silently misbehaving or ready to explode on the next
message to that Actor (as a panic while processing the sent message does
_not_ fail initially).

Given that a panic is usually indicative of a fairly abnormal condition,
it's not necessarily correct to even restart execution in those cases.
For instance, `Mutex` will poison its self if the MutexGuard is dropped
while the thread is panicking. It's also usually desirable to exit the
program and let process supervision handle reinitializing the program.

This PR adds a new builder API to Arbiter to support the `stop_system_on_panic`
option. Future PRs can also use this builder to allow for further
customization.

Usage:
```rust
    let actor: Addr<SomeActor> = Arbiter::builder()
            .name("optional name")
            .stop_system_on_panic(true)
            .start(|_| SomeActor::new());
```

Or to get an `Addr<Arbiter>`:
```rust
    let arbiter: Addr<Arbiter> = Arbiter::builder()
            .name("optional name")
            .stop_system_on_panic(true)
            .build();
```

The existing API (`Arbiter#new`, `Arbiter#start`) uses the builder under
the hood, but does not change the behavior or API surface of the existing
API.

Resolves #110