### PR TITLE
Remove obsolete references to the deleted guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,6 @@ clippy:
 
 doc: build
 	cargo doc --no-deps $(CARGO_FLAGS)
-	cd guide; mdbook build -d ../target/doc/guide/; cd ..
 
 clean:
 	rm -r target

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Actix is a Rust actors framework.
 
-* [User Guide](https://actix.rs/book/actix/)
 * [API Documentation (Development)](http://actix.github.io/actix/actix/)
 * [API Documentation (Releases)](https://docs.rs/actix/)
 * Cargo package: [actix](https://crates.io/crates/actix)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 //!
 //! ## Documentation
 //!
-//! * [User Guide](https://actix.rs/book/actix/)
 //! * [Chat on gitter](https://gitter.im/actix/actix)
 //! * [GitHub repository](https://github.com/actix/actix)
 //! * [Cargo package](https://crates.io/crates/actix)


### PR DESCRIPTION
The content of the [guilde](https://actix.rs/book/actix/) is obsolete, moreover, it seems that the guide have been removed from the repository.
So maybe removing the guide references from README and the API doc