### PR TITLE
Lessen numbers of jobs for AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,26 +3,13 @@ environment:
     PROJECT_NAME: actix
   matrix:
     # Stable channel
-    - TARGET: i686-pc-windows-gnu
-      CHANNEL: stable
     - TARGET: i686-pc-windows-msvc
       CHANNEL: stable
     - TARGET: x86_64-pc-windows-gnu
       CHANNEL: stable
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: stable
-    # Beta channel
-    - TARGET: i686-pc-windows-gnu
-      CHANNEL: beta
-    - TARGET: i686-pc-windows-msvc
-      CHANNEL: beta
-    - TARGET: x86_64-pc-windows-gnu
-      CHANNEL: beta
-    - TARGET: x86_64-pc-windows-msvc
-      CHANNEL: beta
     # Nightly channel
-    - TARGET: i686-pc-windows-gnu
-      CHANNEL: nightly
     - TARGET: i686-pc-windows-msvc
       CHANNEL: nightly
     - TARGET: x86_64-pc-windows-gnu


### PR DESCRIPTION
1. Removes x32 GNU jobs
2. Remove beta jobs. Considering we have nightly to test against, I think beta testing is redundant.