### PR TITLE
run_interval should not fire initially at once

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -113,7 +113,7 @@ impl<A: Actor> IntervalFunc<A> {
     {
         Self {
             f: Box::new(f),
-            interval: Interval::new(Instant::now(), timeout),
+            interval: Interval::new(Instant::now() + timeout, timeout),
         }
     }
 }


### PR DESCRIPTION
The Interval work in the way that it fires at argument at time, and then fires delays with timeout provided.

It may be inconvenient for user so we should fire initially at Instant::now() + timeout