### PR TITLE
chore: upgrade failure to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tokio-timer = "0.2"
 # other
 log = "0.4"
 fnv = "1.0.5"
-failure = "0.1.1"
+failure = "0.1.2"
 bitflags = "1.0"
 smallvec = "0.6"
 crossbeam-channel = "0.2"


### PR DESCRIPTION
I can't start a new actix-web project due to : https://github.com/rust-lang-nursery/failure/issues/234
