### PR TITLE
Do not transfer ownership to the method.

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -128,7 +128,7 @@ impl<A: Actor> Addr<A> {
     }
 
     /// Get `Recipient` for specific message type
-    pub fn recipient<M: 'static>(self) -> Recipient<M>
+    pub fn recipient<M: 'static>(&self) -> Recipient<M>
     where
         A: Handler<M>,
         A::Context: ToEnvelope<A, M>,


### PR DESCRIPTION
There is no necessity to transfer ownership to `Addr::recipient()`. If we transfer ownership to the method, the following code pattern does not work:
```
let addr = ctx.address();

// Pass Recipient<MessageA>
recipients_a.add(addr.recipient());

// Pass Recipient<MessageB>
recipients_b.add(addr.recipient()); // Compiler error: `addr` value used here after move
```