### PR TITLE
Use tokio_timer's Clock abstraction

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # CHANGES
 
+## [0.x.x](2018-1x-xx)
+
+- Introduce the `clock` module to allow overriding and mocking the system clock
+  based on `tokio_timer`.
+
+- System now has `System::builder()` which allows overriding the system clock
+  with a custom instance. `Arbiter::builder()` can now also override the system
+  clock. The default is to inherit from the system.
+
+- New utility classes `TimerFunc` and `IntervalFunc` in the `utils` module.
+
 ## [0.7.4] (2018-08-27)
 
 ### Added

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -43,7 +43,7 @@ extern crate trust_dns_resolver;
 use std::collections::VecDeque;
 use std::io;
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use self::trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
 use self::trust_dns_resolver::lookup_ip::LookupIpFuture;
@@ -52,6 +52,7 @@ use futures::{Async, Future, Poll};
 use tokio_tcp::{ConnectFuture, TcpStream};
 use tokio_timer::Delay;
 
+use clock;
 use prelude::*;
 
 #[deprecated(since = "0.7.0", note = "please use `Resolver` instead")]
@@ -380,7 +381,7 @@ impl TcpConnector {
         TcpConnector {
             addrs,
             stream: None,
-            timeout: Delay::new(Instant::now() + timeout),
+            timeout: Delay::new(clock::now() + timeout),
         }
     }
 }

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -1,10 +1,11 @@
 use std::marker::PhantomData;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::sync::oneshot;
 use futures::{Async, Future, Poll};
 use tokio_timer::Delay;
 
+use clock;
 use handler::{Handler, Message};
 
 use super::channel::{AddressSender, Sender};
@@ -49,7 +50,7 @@ where
 
     /// Set message delivery timeout
     pub fn timeout(mut self, dur: Duration) -> Self {
-        self.timeout = Some(Delay::new(Instant::now() + dur));
+        self.timeout = Some(Delay::new(clock::now() + dur));
         self
     }
 
@@ -130,7 +131,7 @@ where
 
     /// Set message delivery timeout
     pub fn timeout(mut self, dur: Duration) -> Self {
-        self.timeout = Some(Delay::new(Instant::now() + dur));
+        self.timeout = Some(Delay::new(clock::now() + dur));
         self
     }
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -8,4 +8,4 @@
 //!
 //! [Module `tokio_timer::clock`]: https://docs.rs/tokio-timer/latest/tokio_timer/clock/index.html
 
-pub use tokio_timer::clock::*;
+pub use tokio_timer::clock::{now, Clock, Now};

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,0 +1,11 @@
+//! A configurable source of time.
+//!
+//! This module provides an API to get the current instant in such a way that
+//! the source of time may be configured. This allows mocking out the source of
+//! time in tests.
+//!
+//! See [Module `tokio_timer::clock`] for full documentation.
+//!
+//! [Module `tokio_timer::clock`]: https://docs.rs/tokio-timer/latest/tokio_timer/clock/index.html
+
+pub use tokio_timer::clock::*;

--- a/src/contextitems.rs
+++ b/src/contextitems.rs
@@ -1,9 +1,10 @@
 use futures::{Async, Future, Poll, Stream};
 use std::marker::PhantomData;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio_timer::Delay;
 
 use actor::{Actor, ActorContext, AsyncContext};
+use clock;
 use fut::ActorFuture;
 use handler::{Handler, Message, MessageResponse};
 
@@ -57,7 +58,7 @@ where
     pub fn new(msg: M, timeout: Duration) -> Self {
         ActorDelayedMessageItem {
             msg: Some(msg),
-            timeout: Delay::new(Instant::now() + timeout),
+            timeout: Delay::new(clock::now() + timeout),
             act: PhantomData,
             m: PhantomData,
         }

--- a/src/fut/stream_timeout.rs
+++ b/src/fut/stream_timeout.rs
@@ -1,9 +1,10 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use tokio_timer::Delay;
 
 use actor::Actor;
+use clock;
 use fut::ActorStream;
 
 /// Future for the `timeout` combinator, interrupts computations if it takes
@@ -57,7 +58,7 @@ where
         }
 
         if self.timeout.is_none() {
-            self.timeout = Some(Delay::new(Instant::now() + self.dur));
+            self.timeout = Some(Delay::new(clock::now() + self.dur));
         }
 
         // check timeout

--- a/src/fut/timeout.rs
+++ b/src/fut/timeout.rs
@@ -1,9 +1,10 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::{Async, Future, Poll};
 use tokio_timer::Delay;
 
 use actor::Actor;
+use clock;
 use fut::ActorFuture;
 
 /// Future for the `timeout` combinator, interrupts computations if it takes
@@ -28,7 +29,7 @@ where
     Timeout {
         fut: future,
         err: Some(err),
-        timeout: Delay::new(Instant::now() + timeout),
+        timeout: Delay::new(clock::now() + timeout),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ mod address;
 mod mailbox;
 
 pub mod actors;
+pub mod clock;
 pub mod fut;
 pub mod io;
 pub mod msgs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,7 @@ pub mod prelude {
         pub use msgs;
         pub use prelude::*;
         pub use registry::SystemService;
-        pub use utils::Condition;
+        pub use utils::{Condition, IntervalFunc, TimerFunc};
     }
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -308,7 +308,7 @@ impl<I: Send, E: Send> Handler<Execute<I, E>> for SystemArbiter {
 ///     // initialize system and run it
 ///     // This function blocks current thread
 ///     let code = System::builder().clock(clock).run(|| {
-///         // Start `Timer` actor
+///         // Start `Timer` actor. It will use the provided clock instance.
 ///         Timer {
 ///             dur: Duration::new(0, 1),
 ///         }.start();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,11 @@
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::unsync::oneshot;
 use futures::{Async, Future, Poll, Stream};
 use tokio_timer::{Delay, Interval};
 
 use actor::Actor;
+use clock;
 use fut::{ActorFuture, ActorStream};
 
 pub struct Condition<T>
@@ -60,7 +61,7 @@ where
     {
         TimerFunc {
             f: Some(Box::new(f)),
-            timeout: Delay::new(Instant::now() + timeout),
+            timeout: Delay::new(clock::now() + timeout),
         }
     }
 }
@@ -113,7 +114,7 @@ impl<A: Actor> IntervalFunc<A> {
     {
         Self {
             f: Box::new(f),
-            interval: Interval::new(Instant::now() + timeout, timeout),
+            interval: Interval::new(clock::now() + timeout, timeout),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -43,7 +43,45 @@ where
     }
 }
 
-pub(crate) struct TimerFunc<A>
+/// An `ActorFuture` that runs a function in the actor's context after a specified amount of time.
+///
+/// Unless you specifically need access to the future, use [`Context::run_later`] instead.
+///
+/// [`Context::run_later`]: ../prelude/trait.AsyncContext.html#method.run_later
+///
+/// ```rust
+/// # #[macro_use] extern crate actix;
+/// # extern crate futures;
+/// # use std::io;
+/// use std::time::Duration;
+/// use actix::prelude::*;
+/// use actix::utils::TimerFunc;
+///
+/// struct MyActor;
+///
+/// impl MyActor {
+///     fn stop(&mut self, context: &mut Context<Self>) {
+///         System::current().stop();
+///     }
+/// }
+///
+/// impl Actor for MyActor {
+///    type Context = Context<Self>;
+///
+///    fn started(&mut self, context: &mut Context<Self>) {
+///        // spawn a delayed future into our context
+///        TimerFunc::new(Duration::from_millis(100), Self::stop)
+///            .spawn(context);
+///    }
+/// }
+/// # fn main() {
+/// #    let sys = System::new("example");
+/// #    let addr = MyActor.start();
+/// #    sys.run();
+/// # }
+/// ```
+#[must_use = "future do nothing unless polled"]
+pub struct TimerFunc<A>
 where
     A: Actor,
 {
@@ -55,6 +93,7 @@ impl<A> TimerFunc<A>
 where
     A: Actor,
 {
+    /// Creates a new `TimerFunc` with the given duration.
     pub fn new<F>(timeout: Duration, f: F) -> TimerFunc<A>
     where
         F: FnOnce(&mut A, &mut A::Context) + 'static,
@@ -77,7 +116,6 @@ impl<A: Actor, F: FnOnce(&mut A, &mut A::Context) + 'static> TimerFuncBox<A> for
     }
 }
 
-#[doc(hidden)]
 impl<A> ActorFuture for TimerFunc<A>
 where
     A: Actor,
@@ -87,7 +125,9 @@ where
     type Actor = A;
 
     fn poll(
-        &mut self, act: &mut Self::Actor, ctx: &mut <Self::Actor as Actor>::Context,
+        &mut self,
+        act: &mut Self::Actor,
+        ctx: &mut <Self::Actor as Actor>::Context,
     ) -> Poll<Self::Item, Self::Error> {
         match self.timeout.poll() {
             Ok(Async::Ready(_)) => {
@@ -102,12 +142,53 @@ where
     }
 }
 
-pub(crate) struct IntervalFunc<A: Actor> {
+/// An `ActorStream` that periodically runs a function in the actor's context.
+///
+/// Unless you specifically need access to the future, use [`Context::run_interval`] instead.
+///
+/// [`Context::run_interval`]: ../prelude/trait.AsyncContext.html#method.run_interval
+///
+/// ```rust
+/// # #[macro_use] extern crate actix;
+/// # extern crate futures;
+/// # use std::io;
+/// use std::time::Duration;
+/// use actix::prelude::*;
+/// use actix::utils::IntervalFunc;
+///
+/// struct MyActor;
+///
+/// impl MyActor {
+///     fn tick(&mut self, context: &mut Context<Self>) {
+///         println!("tick");
+///     }
+/// }
+///
+/// impl Actor for MyActor {
+///    type Context = Context<Self>;
+///
+///    fn started(&mut self, context: &mut Context<Self>) {
+///        // spawn an interval stream into our context
+///        IntervalFunc::new(Duration::from_millis(100), Self::tick)
+///            .finish()
+///            .spawn(context);
+/// #      context.run_later(Duration::from_millis(200), |_, _| System::current().stop());
+///    }
+/// }
+/// # fn main() {
+/// #    let sys = System::new("example");
+/// #    let addr = MyActor.start();
+/// #    sys.run();
+/// # }
+/// ```
+#[must_use = "future do nothing unless polled"]
+pub struct IntervalFunc<A: Actor> {
     f: Box<IntervalFuncBox<A>>,
     interval: Interval,
 }
 
 impl<A: Actor> IntervalFunc<A> {
+    /// Creates a new `IntervalFunc` with the given interval duration.
     pub fn new<F>(timeout: Duration, f: F) -> IntervalFunc<A>
     where
         F: FnMut(&mut A, &mut A::Context) + 'static,
@@ -130,14 +211,15 @@ impl<A: Actor, F: FnMut(&mut A, &mut A::Context) + 'static> IntervalFuncBox<A> f
     }
 }
 
-#[doc(hidden)]
 impl<A: Actor> ActorStream for IntervalFunc<A> {
     type Item = ();
     type Error = ();
     type Actor = A;
 
     fn poll(
-        &mut self, act: &mut Self::Actor, ctx: &mut <Self::Actor as Actor>::Context,
+        &mut self,
+        act: &mut Self::Actor,
+        ctx: &mut <Self::Actor as Actor>::Context,
     ) -> Poll<Option<Self::Item>, Self::Error> {
         loop {
             match self.interval.poll() {


### PR DESCRIPTION
Tokio's `Registry` allows to set a custom `Clock` instance, which makes it possible to mock all timer related functions in tests. This PR adds the option to set that clock in the `System`'s runtime as well as override it in each `Arbiter`.

There is now `System::builder()`, which allows to set that clock instance and then build a `SystemRunner`. The type level docs have an example for that. It is not publicly exported, just like the Arbiter builder is not exported. Let me know, if you'd like to change that.

To make `Clock`, `Now` (the trait behind it) and `clock::now()` more accessible, this PR also adds a new public `actix::clock` module which contains a basic re-export of `tokio_timer::clock`. That way, users do not have to explicitly add `tokio_timer` to their own crate's dependencies.

It could also make sense to re-export more stuff from `tokio_timer`, like for instance `Delay`. In that case, I would propose renaming that module to `actix::timer`. Also, `utils::TimerFunc` could belong in that module, if you choose to make it available (see #136).

For now, I did not bother to use a mock clock in tests, but that might be a logical addition. Just let me know if you'd like me to update them.

Fixes #136 