### PR TITLE
Update uuid to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ bitflags = "1.0"
 smallvec = "0.6"
 crossbeam-channel = "0.2"
 parking_lot = "0.6"
-uuid = { version = "0.6", features = ["v4"] }
+uuid = { version = "0.7", features = ["v4"] }
 
 # signal handling
 tokio-signal = { version = "0.2", optional = true }

--- a/src/arbiter.rs
+++ b/src/arbiter.rs
@@ -72,7 +72,6 @@ impl Arbiter {
     /// Returns address of newly created arbiter.
     fn new_with_builder(builder: Builder) -> Addr<Arbiter> {
         let (tx, rx) = std::sync::mpsc::channel();
-
         let id = Uuid::new_v4();
         let name = format!(
             "arbiter:{}:{}",
@@ -120,8 +119,7 @@ impl Arbiter {
             // unregister arbiter
             System::current()
                 .sys()
-                .do_send(UnregisterArbiter(
-                    simple().to_string()));
+                .do_send(UnregisterArbiter(id.to_simple_ref().to_string()));
         });
 
         rx.recv().unwrap()

--- a/src/arbiter.rs
+++ b/src/arbiter.rs
@@ -76,7 +76,7 @@ impl Arbiter {
         let id = Uuid::new_v4();
         let name = format!(
             "arbiter:{}:{}",
-            id.hyphenated().to_string(),
+            id.to_hyphenated_ref().to_string(),
             builder.name.as_ref().unwrap_or(&"actor".into())
         );
         let sys = System::current();
@@ -105,7 +105,7 @@ impl Arbiter {
             // register arbiter
             System::current()
                 .sys()
-                .do_send(RegisterArbiter(id.simple().to_string(), addr.clone()));
+                .do_send(RegisterArbiter(id.to_simple_ref().to_string(), addr.clone()));
 
             if tx.send(addr).is_err() {
                 error!("Can not start Arbiter, remote side is dead");
@@ -120,7 +120,8 @@ impl Arbiter {
             // unregister arbiter
             System::current()
                 .sys()
-                .do_send(UnregisterArbiter(id.simple().to_string()));
+                .do_send(UnregisterArbiter(
+                    simple().to_string()));
         });
 
         rx.recv().unwrap()


### PR DESCRIPTION
Updates uuid to the latest release (0.6 to 0.7) which renamed `hyphenated()` to `to_hyphenated_ref()` and `simple()` to `to_simple_ref()`. 