### PR TITLE
Expose API for custom SyncArbiter

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-pub(crate) mod channel;
+pub mod channel;
 mod envelope;
 mod message;
 mod queue;
@@ -12,7 +12,8 @@ use handler::{Handler, Message};
 pub use self::envelope::{Envelope, EnvelopeProxy, ToEnvelope};
 pub use self::message::{RecipientRequest, Request};
 
-pub(crate) use self::channel::{AddressReceiver, AddressSenderProducer};
+pub use self::channel::AddressReceiver;
+pub(crate) use self::channel::AddressSenderProducer;
 use self::channel::{AddressSender, Sender};
 
 pub enum SendError<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,10 @@ pub mod dev {
     pub use prelude::actix::*;
     pub use prelude::*;
 
-    pub use address::{Envelope, RecipientRequest, Request, ToEnvelope};
+    pub use address::{
+        channel, AddressReceiver, Envelope, EnvelopeProxy, RecipientRequest,
+        Request, ToEnvelope,
+    };
     pub use contextimpl::{AsyncContextParts, ContextFut, ContextParts};
     pub use handler::{MessageResponse, ResponseChannel};
     pub use mailbox::Mailbox;


### PR DESCRIPTION
I'm writing a specialized SyncArbiter. This exposes the private APIs that are needed to move src/sync.rs into a separate crate.