### PR TITLE
fix infinite loop in ContextFut::poll() caused by late cancel_future()

### DIFF
--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -376,8 +376,15 @@ where
             }
             self.ctx.parts().handles[1] = SpawnHandle::default();
 
-            // merge returns true if context contains new items
+            // merge returns true if context contains new items or handles to be cancelled
             if self.merge() && !self.ctx.parts().flags.contains(ContextFlags::STOPPING) {
+                // if we have no item to process, cancelled handles wouldn't be
+                // reaped in the above loop. this means self.merge() will never
+                // be false and the poll() never ends. so, discard the handles
+                // as we're sure there are no more items to be cancelled.
+                if self.items.is_empty() {
+                    self.ctx.parts().handles.truncate(2);
+                }
                 continue;
             }
 

--- a/tests/test_context.rs
+++ b/tests/test_context.rs
@@ -406,3 +406,50 @@ fn test_cancel_handler() {
         });
     });
 }
+
+struct CancelLater {
+    handle: Option<SpawnHandle>,
+}
+
+impl Actor for CancelLater {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Context<Self>) {
+        // nothing spawned other than the future to be canceled after completion
+        self.handle = Some(ctx.spawn(future::ok(()).into_actor(self)));
+    }
+}
+
+#[derive(Message)]
+struct CancelMessage;
+
+impl Handler<CancelMessage> for CancelLater {
+    type Result = ();
+
+    fn handle(&mut self, _: CancelMessage, ctx: &mut Self::Context) {
+        ctx.cancel_future(self.handle.take().unwrap());
+    }
+}
+
+#[test]
+fn test_cancel_completed_with_no_context_item() {
+    actix::System::run(|| {
+        // first, spawn future that will complete immediately
+        let addr = CancelLater { handle: None }.start();
+
+        // then, cancel the future which would already be completed
+        tokio::spawn(
+            Delay::new(Instant::now() + Duration::from_millis(100))
+                .map_err(|_| ())
+                .map(move |_| addr.do_send(CancelMessage))
+        );
+
+        // finally, terminate the actor, which shouldn't be blocked unless
+        // the actor context ate up CPU time
+        tokio::spawn(
+            Delay::new(Instant::now() + Duration::from_millis(200))
+                .map_err(|_| ())
+                .map(|_| System::current().stop())
+        );
+   });
+}


### PR DESCRIPTION
Canceled handles are generally consumed in the "process items" loop, but
the loop never runs if there's no item to process. As a result, the handles
are left unprocessed and the 'outer loop never resolves. This patch addresses
the issue by discarding the canceled handles if there's no item still alive.

The test case is a bit hairy. It wouldn't finish without the fix. I couldn't
come up with a better idea.