### PR TITLE
No longer required to use Syn in README.md example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the [`Actor`](https://actix.github.io/actix/actix/trait.Actor.html) trait.
 
 ```rust
 extern crate actix;
-use actix::{msgs, Actor, Addr, Arbiter, Context, Syn, System};
+use actix::{msgs, Actor, Addr, Arbiter, Context, System};
 
 struct MyActor;
 


### PR DESCRIPTION
The example doesn't compile as it is now. I just made the minimum changes to get it running.