### PR TITLE
Updating trust-dns-resolver dependency to version 0.10.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## [0.7.6] (2018-11-08)
+
+### Changed
+
+- Use `trust-dns-resolver` 0.10.0.
+
 ## [0.7.5] (2018-10-10)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ uuid = { version = "0.7", features = ["v4"] }
 tokio-signal = { version = "0.2", optional = true }
 
 # dns resolver
-trust-dns-proto = { version = "^0.4.3", optional = true }
-trust-dns-resolver = { version = "^0.9.1", optional = true }
+trust-dns-proto = { version = "^0.5.0", optional = true }
+trust-dns-resolver = { version = "^0.10.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actor framework for Rust"
 readme = "README.md"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,3 +1,9 @@
+## 0.7.6
+
+- `trust-dns-resolver` dependency was bumped to version 0.10.0. If you use a
+  custom resolver, you will need to switch your `ResolverConfig` and
+  `ResolverOpts` to `trust-dns-resolver` 0.10.0 instead of 0.9.1.
+
 ## 0.7
 
 * `Addr` get refactored. `Syn` and `Unsync` removed. all addresses are

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -48,13 +48,14 @@ use std::net::SocketAddr;
 use std::time::Duration;
 
 use self::trust_dns_resolver::config::{ResolverConfig, ResolverOpts};
-use self::trust_dns_resolver::lookup_ip::LookupIpFuture;
-use self::trust_dns_resolver::ResolverFuture;
+use self::trust_dns_resolver::AsyncResolver;
+use self::trust_dns_resolver::BackgroundLookupIp;
 use futures::{Async, Future, Poll};
 use tokio_tcp::{ConnectFuture, TcpStream};
 use tokio_timer::Delay;
 
 use clock;
+use fut::wrap_future;
 use prelude::*;
 
 #[deprecated(since = "0.7.0", note = "please use `Resolver` instead")]
@@ -153,7 +154,7 @@ pub enum ResolverError {
 }
 
 pub struct Resolver {
-    resolver: Option<ResolverFuture>,
+    resolver: Option<AsyncResolver>,
     cfg: Option<(ResolverConfig, ResolverOpts)>,
     err: Option<String>,
 }
@@ -166,37 +167,47 @@ impl Resolver {
             err: None,
         }
     }
+
+    fn start_resolver<F>(
+        &self, ctx: &mut <Self as Actor>::Context, parts: (AsyncResolver, F),
+    ) -> AsyncResolver
+    where
+        F: 'static + Future<Item = (), Error = ()>,
+    {
+        ctx.spawn(wrap_future::<_, Self>(parts.1));
+        parts.0
+    }
 }
 
 impl Actor for Resolver {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
+        // AsyncResolver::new() returns the AsyncResolver itself, plus an anonymous
+        // future which gets spawned as a background task for doing DNS
+        // resolution. So we use our litle `start_resolver` wrapper to spawn
+        // the background task (which gets cleaned up automatically if no
+        // outstanding AsyncResolvers stil have a handle to it).
         let resolver = if let Some(cfg) = self.cfg.take() {
-            ResolverFuture::new(cfg.0, cfg.1)
+            self.start_resolver(ctx, AsyncResolver::new(cfg.0, cfg.1))
         } else {
-            match ResolverFuture::from_system_conf() {
-                Ok(resolver) => resolver,
+            match AsyncResolver::from_system_conf() {
+                Ok(resolver) => self.start_resolver(ctx, resolver),
                 Err(err) => {
                     warn!("Can not create system dns resolver: {}", err);
-                    ResolverFuture::new(
-                        ResolverConfig::default(),
-                        ResolverOpts::default(),
+                    self.start_resolver(
+                        ctx,
+                        AsyncResolver::new(
+                            ResolverConfig::default(),
+                            ResolverOpts::default(),
+                        ),
                     )
                 }
             }
         };
 
-        resolver
-            .into_actor(self)
-            .map(|resolver, act, _| {
-                act.resolver = Some(resolver);
-            })
-            .map_err(|err, act, _| {
-                error!("Can not create resolver: {}", err);
-                act.err = Some(format!("Can not create resolver: {}", err));
-            })
-            .wait(ctx);
+        // Keep the resolver itself.
+        self.resolver = Some(resolver);
     }
 }
 
@@ -257,7 +268,7 @@ impl Handler<ConnectAddr> for Resolver {
 
 /// Resolver future
 struct ResolveFut {
-    lookup: Option<LookupIpFuture>,
+    lookup: Option<BackgroundLookupIp>,
     port: u16,
     addrs: Option<VecDeque<SocketAddr>>,
     error: Option<ResolverError>,
@@ -266,7 +277,7 @@ struct ResolveFut {
 
 impl ResolveFut {
     pub fn new<S: AsRef<str>>(
-        addr: S, port: u16, resolver: &ResolverFuture,
+        addr: S, port: u16, resolver: &AsyncResolver,
     ) -> ResolveFut {
         // try to parse as a regular SocketAddr first
         if let Ok(addr) = addr.as_ref().parse() {


### PR DESCRIPTION
trust-dns-resolver 0.10.0 has additional, useful options (e.g., max TTL) that can be passed in via ResolverOpts. These newer options are not available in trust-dns-resolver 0.9.1, which is what Actix currently depends on. This pull request updates Actix to depend on trust-dns-resolver 0.10.

What trust-dns-resolver used to call ResolverFuture is now called AsyncResolver. When creating an AsyncResolver, instead of being given a Future which must be waited on to construct the Resolver, you are immediately given an AsyncResolver, plus a background task that must be spawned to perform DNS lookups (https://docs.rs/trust-dns-resolver/0.10.0/trust_dns_resolver/struct.AsyncResolver.html). This pull request essentially does the renaming of types, plus spawns the background task.