### PR TITLE
Echo example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ tokio-signal = { version = "0.2", optional = true }
 trust-dns-proto = { version = "^0.5.0", optional = true }
 trust-dns-resolver = { version = "^0.10.0", optional = true }
 
-[dev-dependences]
+[dev-dependencies]
 env_logger = "0.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ tokio-signal = { version = "0.2", optional = true }
 trust-dns-proto = { version = "^0.5.0", optional = true }
 trust-dns-resolver = { version = "^0.10.0", optional = true }
 
+[dev-dependences]
+env_logger = "0.5"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -14,6 +14,17 @@
 //! example can be stopped by either sending EOF via Ctrl+D or terminating the
 //! process with Ctrl+C.
 //!
+//! To run the example with logging statements for observation of actor
+//! life-cycles, start the example with the following command:
+//!
+//! ```text
+//! $ RUST_LOG=echo=trace cargo run --example echo
+//! ```
+//!
+//! This will print any logging statements within _this_ example. If the
+//! `RUST_LOG=echo=trace` is replaced with `RUST_LOG=trace`, then all logging
+//! statements within all dependencies and _this_ example will be printed.
+//!
 //! # Details
 //!
 //! Three actors are created: (1) [`Stdin`], (2) [`Stdout`], and (3) ['Echo'].

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -56,20 +56,22 @@ use tokio::io;
 
 /// The message sent from the [`Stdin`] actor to a recipient.
 ///
-/// The Stdin actor publishes (sends) this message to a subscriber (recipient)
-/// and it is just a thin wrapper around a series of bytes from STDIN.
+/// The Stdin actor publishes (sends) this message to a subscriber (recipient).
+/// This message is just a thin wrapper around a series of bytes from STDIN.
 ///
 /// [`Stdin`]: struct.Stdin.html
 #[derive(Message)]
 struct Input(pub BytesMut);
 
+// A conversion helper implementation for converting BytesMut into the wrapper
+// Input message.
 impl From<BytesMut> for Input {
     fn from(b: BytesMut) -> Self {
         Input(b)
     }
 }
 
-/// The message received by the [`Stdout`] actor.
+/// The message handled by the [`Stdout`] actor.
 ///
 /// The Stdout actor writes the message, which is just a thin wrapper around a
 /// series of bytes, to STDOUT.
@@ -78,11 +80,9 @@ impl From<BytesMut> for Input {
 #[derive(Message)]
 struct Output(pub Bytes);
 
-// A simple conversion of an [`Input`] message to an [`Output`] message so that
-// the Stdin actor can easily "forward" its messages to the Stdout actor.
-//
-// [`Input`]: struct.Input.html
-// [`Output`]: struct.Output.html
+// A conversion helper of an Input message to an Output message so that
+// the Echo actor can easily convert the Input message from the Stdin actor to
+// the Output message of the Stdout actor.
 impl From<Input> for Output {
     fn from(i: Input) -> Self {
         Output(i.0.freeze())
@@ -103,6 +103,11 @@ impl From<Input> for Output {
 /// [`Output`]: struct.Output.html
 /// [`Stream`]: https://docs.rs/futures/0.1.25/futures/stream/trait.Stream.html
 struct Stdout {
+    /// The sender of the internal channel used to communicate with the STDOUT
+    /// thread.
+    ///
+    /// When this is dropped, the STDOUT thread will be stopped and the actix
+    /// system is shutdown.
     tx: UnboundedSender<Bytes>,
 }
 
@@ -145,8 +150,8 @@ impl Stdout {
     }
 }
 
-// Added trace statements to help demonstrate the interaction between the Stdin
-// and Stdout actors.
+// Added trace logging statements to help demonstrate the life-cycle of this
+// actor.
 impl Actor for Stdout {
     type Context = Context<Self>;
 
@@ -164,10 +169,10 @@ impl Actor for Stdout {
     }
 }
 
-// The Stdout actor receives Output messages.
+// The Stdout actor handles Output messages.
 //
-// The handler of the Output messages for the Stdout actor is relatively simple.
-// The Output message is sent to the STDOUT thread using the internal channel.
+// This is relatively simple. Output messages are sent to the STDOUT thread
+// using the internal channel as a series of bytes.
 impl Handler<Output> for Stdout {
     type Result = ();
 
@@ -177,7 +182,7 @@ impl Handler<Output> for Stdout {
     }
 }
 
-// A little conversion helper to clean up creation of a Stdout actor from an
+// A conversion helper to clean up creation of a Stdout actor from an
 // encoder/codec. Uses the current actix system.
 impl<E> From<E> for Stdout
     where E: Encoder<Item=Bytes, Error=Error> + Send + Clone + 'static
@@ -190,15 +195,21 @@ impl<E> From<E> for Stdout
 /// An actor that reads bytes from STDIN.
 ///
 /// This actor starts a separate thread to avoid blocking and uses a channel to
-/// receive bytes at an [`Input`] message from the separate thread. The channel
-/// only has one sender (tx). When STDIN receives an End-of-File (EOF) signal,
-/// the sender will be dropped. This causes the receiver within this actor to
-/// become resolved, i.e. completed. The resolution of the receiver stops this
-/// actor.
+/// receive a continuous stream of messages from the separate thread. The channel
+/// only has one sender (tx), which is moved to the separate thread. When STDIN
+/// receives an End-of-File (EOF) signal, the sender will be dropped. This
+/// causes the receiver within this actor to become resolved, i.e. completed.
+/// The resolution of the receiver stops this actor.
+///
+/// This actor is implemented as a publisher, in that it does not receive
+/// messages from other actors. Instead, it publishes [`Input`] messages to a
+/// subscriber (recipient).
 ///
 /// [`Input`]: struct.Input.html
 struct Stdin<D> {
+    /// The subscriber of the published Input messages.
     recipient: Recipient<Input>,
+    /// Decodes the stream of bytes from STDIN into framed messages.
     decoder: D,
 }
 
@@ -233,7 +244,7 @@ impl<D> Stdin<D>
 // A separate thread is started when this actor is started. The separate thread
 // reads bytes from STDIN and sends them to this actor using an internal
 // channel. This implementation of the Actor trait also includes trace
-// logging statements to demonstrate the interaction with the Stdout actor.
+// logging statements to demonstrate the life-cycle of this actor.
 impl<D> Actor for Stdin<D>
     where D: Decoder<Item=BytesMut, Error=Error> + Send + Clone + 'static
 {
@@ -271,6 +282,12 @@ impl<D> Actor for Stdin<D>
     }
 }
 
+// The Stdin actor handles the stream of frames from STDIN thread using a
+// channel. The receiver is "attached" to the execution context of this actor,
+// which means it must implement a stream handler. Using the helper conversion
+// for the Input message, i.e. `std::convert::From<BytesMut>`, the frames of
+// bytes are easily transformed into Input messages and published/sent to the
+// subscriber/recipient.
 impl<D> StreamHandler<BytesMut, ()> for Stdin<D>
     where D: Decoder<Item=BytesMut, Error=Error> + Send + Clone + 'static
 {
@@ -280,11 +297,30 @@ impl<D> StreamHandler<BytesMut, ()> for Stdin<D>
     }
 }
 
+/// An actor that implements the main functionality of the example/application.
+///
+/// This actor subscribes to Input messages from the [`Stdin`] actor, converts
+/// the [`Input`] message into an [`Output`] message, and sends the Output
+/// message to the [`Stdout`] actor. In this fashion, the actor echos, forwards,
+/// and/or copies the contents from STDIN to STDOUT.
+///
+/// [`Input`]: struct.Input.html
+/// [`Output`]: struct.Output.html
+/// [`Stdin`]: struct.Stdin.html
+/// [`Stdout`]: struct.Stdout.html
 struct Echo {
+    /// The address of the [`Stdout`] actor.
+    ///
+    /// [`Stdout`]: struct.Stdout.html
     stdout: Addr<Stdout>,
 }
 
 impl Echo {
+    /// Creates a new `Echo` actor.
+    ///
+    /// Only the address of the [`Stdout`] actor is needed.
+    ///
+    /// [`Stdout`]: struct.Stdout.html
     pub fn new(stdout: Addr<Stdout>) -> Self {
         Echo {
             stdout: stdout,
@@ -292,10 +328,29 @@ impl Echo {
     }
 }
 
+// Added trace logging statements to demonstrate the life-cycle of this actor.
 impl Actor for Echo {
     type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDOUT started");
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        trace!("STDOUT stopping");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDOUT stopped");
+    }
 }
 
+// Since the Echo actor is a recipient, or subscriber, of messages from the
+// Stdin actor, it must implement a handler for Input messages. The
+// implementation is very simple using the conversion helpers and the address of
+// the Stdout actor. The Input message is converted to an Output message and
+// sent to the Stdout actor.
 impl Handler<Input> for Echo {
     type Result = ();
 
@@ -305,14 +360,35 @@ impl Handler<Input> for Echo {
     }
 }
 
+// A conversion helper to create an Echo actor from a Stdout actor.
 impl From<Addr<Stdout>> for Echo {
     fn from(s: Addr<Stdout>) -> Self {
         Echo::new(s)
     }
 }
 
+/// A wrapper codec for the [`tokio::codec::LinesCodec`].
+///
+/// Since the `tokio::codec::LinesCodec` decodes and encodes items of the
+/// [`String`] type, it cannot be directly used with the [`Stdin`] and
+/// [`Stdout`] actors. The `Stdin` and `Stdout` actors use decoders and
+/// encoders with [`BytesMut`] and [`Bytes`] items, respectively. Thus, a new
+/// codec type that wraps the `tokio::codec::LinesCodec` and handles the
+/// conversion of `String` items to `BytesMut` and `Bytes` items is implemented.
+/// By wrapping the `tokio::codec::LinesCodec`, the functionality is
+/// maintained and the type requirements for using the `Stdin` and `Stdout`
+/// actors are met.
+///
+/// [`Bytes`]: https://carllerche.github.io/bytes/bytes/struct.Bytes.html
+/// [`BytesMut`]: https://carllerche.github.io/bytes/bytes/struct.BytesMut.html
+/// [`String`]: https://doc.rust-lang.org/std/string/struct.String.html
+/// [`Stdin`]: struct.Stdin.html
+/// [`Stdout`]: struct.Stdout.html
+/// [`tokio::codec::LinesCodec`]: https://tokio-rs.github.io/tokio/tokio/codec/struct.LinesCodec.html
 #[derive(Clone)]
 struct LinesCodec {
+    /// The tokio codec that actually implements reading and writing strings
+    /// terminated by an End-of-Line (EOL) marker.
     inner: tokio::codec::LinesCodec,
 }
 
@@ -343,12 +419,36 @@ impl Default for LinesCodec {
 }
 
 fn main() {
+    // Initialize the logger.
+    //
+    // Use `RUST_LOG=echo=trace cargo run --example echo` to display only the
+    // logging statements from this example. Running `RUST_LOG=trace cargo run
+    // --example echo` will result in logging statements from the entire tokio
+    // and mio stack to be displayed.
     env_logger::init();
+
+    // Start the actix system. Note, the Stdin and Stdout actors will
+    // automatically create the separate threads to read and writing from STDIN
+    // and STDOUT in a non-blocking fashion, respectively. All that is required
+    // is to create and start the three actors, Stdin, Stdout, and Echo, in the
+    // proper order.
+    //
+    // Notice because of all of the conversion helpers that are implemented for
+    // each actor, running the echo example is essentially on line of code.
     let code = System::run(|| {
         Stdin::new(
             LinesCodec::default(),
+            // Because the Stdin and Stdout actors are implemented with generic
+            // decoders and encoders, respectively, it is relatively easy to modify
+            // this example to read lines of text from STDIN but have STDOUT write
+            // the lines in an entirely different format. Simply change the
+            // encoder/codec for the Stdout actor.
             Echo::new(Stdout::from(LinesCodec::default()).start()).start().recipient()
         ).start();
     });
+    // Exit the example/application with an appropriate exit code. When the
+    // example/application successfully terminates, the error code will be zero
+    // (0), which is convention. On failure, a non-zero value is used for the
+    // exit code.
     std::process::exit(code);
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -55,6 +55,10 @@ impl Actor for Stdout {
         trace!("STDOUT started");
     }
 
+    fn stopping(&mut sef, _ctx: &mut Self::Context) {
+        trace!("STDOUT stopping");
+    }
+
     fn stopped(&mut self, _ctx: &mut Self::Context) {
         trace!("STDOUT stopped");
     }
@@ -104,6 +108,10 @@ impl Actor for Stdin {
 
     fn started(&mut self, _ctx: &mut Self::Context) {
         trace!("STDIN started");
+    }
+
+    fn stopping(&mut sef, _ctx: &mut Self::Context) {
+        trace!("STDIN stopping");
     }
 
     fn stopped(&mut self, _ctx: &mut Self::Context) {

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -14,11 +14,11 @@ use tokio::codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec};
 use tokio::io;
 
 #[derive(Message)]
-struct Message(pub String);
+struct Output(pub String);
 
-impl From<String> for Message {
+impl From<String> for Output {
     fn from(s: String) -> Self {
-        Message(s)
+        Output(s)
     }
 }
 
@@ -65,10 +65,10 @@ impl Actor for Stdout {
     }
 }
 
-impl Handler<Message> for Stdout {
+impl Handler<Output> for Stdout {
     type Result = ();
 
-    fn handle(&mut self, msg: Message, _ctx: &mut Context<Self>) {
+    fn handle(&mut self, msg: Output, _ctx: &mut Context<Self>) {
         self.tx.clone().send(msg.0).wait().expect("Send message");
     }
 }
@@ -88,14 +88,14 @@ impl<E> From<E> for Stdout
 }
 
 struct Stdin<D> {
-    recipient: Recipient<Message>,
+    recipient: Recipient<Output>,
     codec: D,
 }
 
 impl<D> Stdin<D>
     where D: Decoder<Item=String, Error=Error> + Send + Clone + 'static
 {
-    pub fn new(codec: D, recipient: Recipient<Message>) -> Self {
+    pub fn new(codec: D, recipient: Recipient<Output>) -> Self {
         Stdin {
             recipient: recipient,
             codec: codec,
@@ -140,12 +140,12 @@ impl<D> Actor for Stdin<D>
     }
 }
 
-impl<D> Handler<Message> for Stdin<D>
+impl<D> Handler<Output> for Stdin<D>
     where D: Decoder<Item=String, Error=Error> + Send + Clone + 'static
 {
     type Result = ();
 
-    fn handle(&mut self, item: Message, _ctx: &mut Self::Context) {
+    fn handle(&mut self, item: Output, _ctx: &mut Self::Context) {
         self.recipient.do_send(item).unwrap();
     }
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -84,6 +84,7 @@ impl Handler<Output> for Stdout {
     type Result = ();
 
     fn handle(&mut self, msg: Output, _ctx: &mut Context<Self>) {
+        trace!("STDOUT handle");
         self.tx.clone().send(msg.0).wait().expect("Send message");
     }
 }
@@ -161,6 +162,7 @@ impl<D> Handler<Input> for Stdin<D>
     type Result = ();
 
     fn handle(&mut self, item: Input, _ctx: &mut Self::Context) {
+        trace!("STDIN handle");
         self.recipient.do_send(item.into()).unwrap();
     }
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,24 +1,34 @@
-//! This example copies, or forwards, lines from STDIN to STDOUT until either
-//! the End-of-File (EOF) marker is reached on STDIN or the application is
-//! terminated.
+//! This example echos, forwards, or copies, lines from STDIN to STDOUT until
+//! either the End-of-File (EOF) marker is reached on STDIN or the application
+//! is terminated.
+//!
+//! Two actors are created: (1) [`Stdin`] and (2) [`Stdout`]. The Stdin actor
+//! reads lines from STDIN and sends the lines to a recipient. In this case, the
+//! recipient is the Stdout actor. The Stdin actor only receives [`Input`]
+//! messages, which could come from another actor, but typically only come from
+//! the STDIN thread. The Stdout actor receives [`Output`] messages from any
+//! actor. In this case, the Stdout actor is the recipient of the Stdin actor.
+//! The Stdout actor sends the Output messages to the STDOUT thread via a
+//! channel.
 //!
 //! Reading and writing to STDIN and STDOUT within the [tokio runtime] is not
 //! straight-forward because these are blocking actions. The current
 //! recommendation is to have reading from STDIN and writing to STDOUT in
 //! separate threads from the tokio runtime thread and use channels to pass data
 //! between the three threads. This is discussed in tokio's [Issue 374] and
-//! tokio-process [Issue 7]. The [tokio-stdin] and [tokio-stdout] crates are
+//! tokio-process's [Issue 7]. The [tokio-stdin] and [tokio-stdout] crates are
 //! implementations based on these recommendations for reading and writing from
-//! STDIN and STDOUT with the tokio runtime, respectively. Thus, the [`Stdin`]
+//! STDIN and STDOUT within the tokio runtime, respectively. Thus, the [`Stdin`]
 //! and [`Stdout`] actors are implemented in a similar fashion.
 //!
-//! [tokio runtime]: https://tokio.rs/blog/2018-03-tokio-runtime/
+//! [`Input`]: #struct.input
 //! [Issue 374]: https://github.com/tokio-rs/tokio/issues/374
 //! [Issue 7]: https://github.com/alexcrichton/tokio-process/issues/7
-//! [tokio-stdin]: https://crates.io/crates/tokio-stdin
-//! [tokio-stdout]: https://crates.io/crates/tokio-stdout
 //! [`Stdin`]: #struct.stdin
 //! [`Stdout`]: #struct.stdout
+//! [tokio-stdin]: https://crates.io/crates/tokio-stdin
+//! [tokio-stdout]: https://crates.io/crates/tokio-stdout
+//! [tokio runtime]: https://tokio.rs/blog/2018-03-tokio-runtime/
 
 extern crate actix;
 extern crate bytes;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,0 +1,116 @@
+extern crate actix;
+#[macro_use]
+extern crate log;
+extern crate futures;
+extern crate tokio;
+
+use actix::prelude::*;
+use futures::{Future, Sink, Stream};
+use futures::sync::mpsc::{self, UnboundedSender};
+use std::io::{Error, ErrorKind};
+use std::thread;
+use tokio::codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec};
+use tokio::io;
+
+#[derive(Message)]
+struct Message(pub String);
+
+impl From<String> for Message {
+    fn from(s: String) -> Self {
+        Message(s)
+    }
+}
+
+struct Stdout {
+    tx: UnboundedSender<String>,
+}
+
+impl Stdout {
+    pub fn new<E>(codec: E) -> Self
+        where E: Encoder<Item=String, Error=Error> + Send + Clone + 'static
+    {
+        let (tx, rx) = mpsc::unbounded();
+        thread::spawn(|| {
+            tokio::run(rx.for_each(move |msg| {
+                FramedWrite::new(io::stdout(), codec.clone())
+                    .send(msg)
+                    .map(|_| ())
+                    .map_err(|err| error!("STDOUT Error = {}", err))
+            }));
+        });
+        Stdout {
+            tx: tx
+        }
+    }
+}
+
+impl Actor for Stdout {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDOUT started");
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDOUT stopped");
+    }
+}
+
+impl Handler<Message> for Stdout {
+    type Result = ();
+
+    fn handle(&mut self, msg: Message, _ctx: &mut Context<Self>) {
+        self.tx.clone().send(msg.0).wait().expect("Send message");
+    }
+}
+
+impl Default for Stdout {
+    fn default() -> Self {
+        Stdout::new(LinesCodec::new())
+    }
+}
+
+struct Stdin;
+
+impl Stdin {
+    pub fn new<D, M, R>(codec: D, recipient: Recipient<M>) -> Self
+        where D: Decoder<Item=String, Error=Error> + Send + 'static,
+              M: actix::Message<Result=R> + std::convert::From<String> + Send + 'static,
+              R: Send + 'static
+    {
+        thread::spawn(|| {
+            tokio::run(FramedRead::new(io::stdin(), codec)
+                .for_each(move |msg| {
+                    recipient.do_send(msg.into())
+                        .map_err(|_| Error::new(ErrorKind::Other, "Send Error"))
+                })
+                .map_err(|err| {
+                    error!("STDIN Error = {}", err);
+                })
+            );
+        });
+        Stdin {}
+    }
+}
+
+impl Actor for Stdin {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDIN started");
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        trace!("STDIN stopped");
+    }
+}
+
+fn main() {
+    let code = System::run(|| {
+        Stdin::new(
+            LinesCodec::new(),
+            Stdout::default().start().recipient()
+        ).start();
+    });
+    std::process::exit(code);
+}

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,3 +1,25 @@
+//! This example copies, or forwards, lines from STDIN to STDOUT until either
+//! the End-of-File (EOF) marker is reached on STDIN or the application is
+//! terminated.
+//!
+//! Reading and writing to STDIN and STDOUT within the [tokio runtime] is not
+//! straight-forward because these are blocking actions. The current
+//! recommendation is to have reading from STDIN and writing to STDOUT in
+//! separate threads from the tokio runtime thread and use channels to pass data
+//! between the three threads. This is discussed in tokio's [Issue 374] and
+//! tokio-process [Issue 7]. The [tokio-stdin] and [tokio-stdout] crates are
+//! implementations based on these recommendations for reading and writing from
+//! STDIN and STDOUT with the tokio runtime, respectively. Thus, the [`Stdin`]
+//! and [`Stdout`] actors are implemented in a similar fashion.
+//!
+//! [tokio runtime]: https://tokio.rs/blog/2018-03-tokio-runtime/
+//! [Issue 374]: https://github.com/tokio-rs/tokio/issues/374
+//! [Issue 7]: https://github.com/alexcrichton/tokio-process/issues/7
+//! [tokio-stdin]: https://crates.io/crates/tokio-stdin
+//! [tokio-stdout]: https://crates.io/crates/tokio-stdout
+//! [`Stdin`]: #struct.stdin
+//! [`Stdout`]: #struct.stdout
+
 extern crate actix;
 extern crate bytes;
 extern crate env_logger;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,6 @@
 //! This example echos, forwards, or copies, lines from STDIN to STDOUT until
-//! either the End-of-File (EOF) marker is reached on STDIN or the application
-//! is terminated.
+//! either the End-of-File (EOF) is reached on STDIN (Ctrl+D) or the application
+//! is terminated (Ctrl+C).
 //!
 //! Three actors are created: (1) [`Stdin`], (2) [`Stdout`], and (3) ['Echo'].
 //! The Stdin actor reads lines from STDIN and sends the lines to a recipient.

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -79,6 +79,14 @@ impl Default for Stdout {
     }
 }
 
+impl<E> From<E> for Stdout
+    where E: Encoder<Item=String, Error=Error> + Send + Clone + 'static
+{
+    fn from(e: E) -> Self {
+        Stdout::new(System::current(), e)
+    }
+}
+
 struct Stdin<D> {
     recipient: Recipient<Message>,
     codec: D,

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -2,6 +2,20 @@
 //! either the End-of-File (EOF) is reached on STDIN (Ctrl+D) or the application
 //! is terminated (Ctrl+C).
 //!
+//! To run the example, start a terminal and navigate to the actix project root
+//! and execute:
+//!
+//! ```text
+//! $ cargo run --example echo
+//! ```
+//!
+//! After executing the above command, text can be typed in the terminal and
+//! will be written/printed on the next line after pressing the `ENTER` key. The
+//! example can be stopped by either sending EOF via Ctrl+D or terminating the
+//! process with Ctrl+C.
+//!
+//! # Details
+//!
 //! Three actors are created: (1) [`Stdin`], (2) [`Stdout`], and (3) ['Echo'].
 //! The Stdin actor reads lines from STDIN and sends the lines to a recipient.
 //! In this case, the recipient is the Echo actor. The Stdin actor handles a

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -85,12 +85,6 @@ impl Handler<Output> for Stdout {
     }
 }
 
-impl Default for Stdout {
-    fn default() -> Self {
-        Stdout::new(System::current(), LinesCodec::default())
-    }
-}
-
 impl<E> From<E> for Stdout
     where E: Encoder<Item=Bytes, Error=Error> + Send + Clone + 'static
 {
@@ -199,7 +193,7 @@ fn main() {
     let code = System::run(|| {
         Stdin::new(
             LinesCodec::default(),
-            Stdout::default().start().recipient()
+            Stdout::from(LinesCodec::default()).start().recipient()
         ).start();
     });
     std::process::exit(code);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -14,11 +14,26 @@ use tokio::codec::{Decoder, Encoder, FramedRead, FramedWrite, LinesCodec};
 use tokio::io;
 
 #[derive(Message)]
+struct Input(pub String);
+
+impl From<String> for Input {
+    fn from(s: String) -> Self {
+        Input(s)
+    }
+}
+
+#[derive(Message)]
 struct Output(pub String);
 
 impl From<String> for Output {
     fn from(s: String) -> Self {
         Output(s)
+    }
+}
+
+impl From<Input> for Output {
+    fn from(i: Input) -> Self {
+        Output(i.0)
     }
 }
 
@@ -140,13 +155,13 @@ impl<D> Actor for Stdin<D>
     }
 }
 
-impl<D> Handler<Output> for Stdin<D>
+impl<D> Handler<Input> for Stdin<D>
     where D: Decoder<Item=String, Error=Error> + Send + Clone + 'static
 {
     type Result = ();
 
-    fn handle(&mut self, item: Output, _ctx: &mut Self::Context) {
-        self.recipient.do_send(item).unwrap();
+    fn handle(&mut self, item: Input, _ctx: &mut Self::Context) {
+        self.recipient.do_send(item.into()).unwrap();
     }
 }
 


### PR DESCRIPTION
As a learning exercise for the Actor model and using actix, I thought I would create a simple "echo" application that echos, forwards, and/or copies the content from STDIN to STDOUT. After completing a working application, I thought it might be helpful for others if it was included as an example for the project.

Since I am still learning, I would appreciate any discussion and feedback on the implementation. Is there (currently) a more idiomatic way of asynchronously reading from STDIN and writing to STDOUT using actix/tokio? I had done some research prior to working on this implementation, and based on this research, I made notes within the module-level comments about reading and writing from standard IO with tokio. I believe based on this research, the implementation in this example is (currently) reasonable, but given the heavy development of the rust asynchronous ecosystem, I am sure I have missed something.

I am also unaware of any existing implementations, or plans, for asynchronously reading from STDIN and writing to STDOUT using actix. There is the [tokio-fs] crate that provides asynchronous file and standard stream adaptation, but there appears to be no actor-based implementation. If acceptable, then maybe the `Stdin` and `Stdout` actors implemented in this example can be moved to the `actors` module of the crate to make it easier for others to include reading and writing to and from standard IO in their actix-based projects? To this end, I have included API-level documentation for the actors within the example.

[tokio-fs]: https://github.com/tokio-rs/tokio/tree/master/tokio-fs