### PR TITLE
Improve the wording of public API documentation

### DIFF
--- a/src/actors/mocker.rs
+++ b/src/actors/mocker.rs
@@ -1,4 +1,5 @@
-//! Mocking utility actor
+//! Mocking utility actor.
+//!
 //! This actor wraps any actor, and replaces instances of that actor with
 //! mocker actor, which is able to accept all messages which the actor can
 //! receive.
@@ -10,16 +11,17 @@
 //! #[cfg(test)]
 //! type DBClientAct = Mocker<DBClientActor>;
 //! ```
-//! Then, the actor should be used as a System Service (or Arbiter Service, but
-//! take care that all the places which will use the mocked actor is on the
+//! Then, the actor should be used as a system service (or arbiter service, but
+//! take care that all the places which will use the mocked actor are on the
 //! same arbiter). Thus, in a test, it will retrieve the mocker from the
 //! registry instead of the actual actor.
 //!
-//! To set the mock function in the actor, the init_actor function is used,
-//! which allows the state of an actor to be set when it is started as a
-//! arbiter or system service. A closure which takes Box<Any> is evaluated for
-//! every message, and must return Box<Any>, specifically the return type
-//! for the message type send.
+//! To set the mock function in the actor, the `init_actor` function
+//! is used, which allows the state of an actor to be set when it is
+//! started as an arbiter or system service. A closure which takes
+//! `Box<Any>` is evaluated for every message, and must return
+//! `Box<Any>`, specifically the return type for the message type
+//! send.
 //!
 //! See the mock example to see how it can be used.
 
@@ -32,7 +34,7 @@ use prelude::*;
 
 /// This actor is able to wrap another actor and accept all the messages the
 /// wrapped actor can, passing it to a closure which can mock the response of
-/// the actors
+/// the actor.
 pub struct Mocker<T: Sized + 'static> {
     phantom: PhantomData<T>,
     mock: Box<FnMut(Box<Any>, &mut Context<Mocker<T>>) -> Box<Any>>,

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -267,7 +267,7 @@ impl Handler<ConnectAddr> for Resolver {
     }
 }
 
-/// Resolver future
+/// A resolver future.
 struct ResolveFut {
     lookup: Option<BackgroundLookupIp>,
     port: u16,
@@ -379,7 +379,7 @@ impl ActorFuture for ResolveFut {
     }
 }
 
-/// Tcp stream connector
+/// A TCP stream connector.
 pub struct TcpConnector {
     addrs: VecDeque<SocketAddr>,
     timeout: Delay,

--- a/src/actors/signal.rs
+++ b/src/actors/signal.rs
@@ -1,8 +1,9 @@
-//! An actor implementation of Unix signal handling
+//! An actor implementation of Unix signal handling.
 //!
-//! This module implements asynchronous signal handling for Actix. For each
-//! signal `ProcessSignals` actor sends `Signal` message to all subscriber. To
-//! subscriber, send `Subscribe` message to `ProcessSignals` actor.
+//! This module implements asynchronous signal handling for Actix. For
+//! each signal, the `ProcessSignals` actor sends a `Signal` message
+//! to all subscribers. To subscribe, send a `Subscribe` message to
+//! the `ProcessSignals` actor.
 //!
 //! # Examples
 //!
@@ -70,18 +71,18 @@ use std;
 
 use prelude::*;
 
-/// Different types of process signals
+/// Represents the different types of signals a process can receive.
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum SignalType {
-    /// SIGHUP
+    /// `SIGHUP`
     Hup,
-    /// SIGINT
+    /// `SIGINT`
     Int,
-    /// SIGTERM
+    /// `SIGTERM`
     Term,
-    /// SIGQUIT
+    /// `SIGQUIT`
     Quit,
-    /// SIGCHILD
+    /// `SIGCHLD`
     Child,
 }
 
@@ -89,7 +90,7 @@ impl Message for SignalType {
     type Result = ();
 }
 
-/// Process signal message
+/// A message representing a received signal.
 #[derive(Debug)]
 pub struct Signal(pub SignalType);
 
@@ -97,7 +98,7 @@ impl Message for Signal {
     type Result = ();
 }
 
-/// An actor implementation of Unix signal handling
+/// An actor that handles Unix signals.
 pub struct ProcessSignals {
     subscribers: Vec<Recipient<Signal>>,
 }
@@ -191,7 +192,6 @@ impl Message for Subscribe {
     type Result = ();
 }
 
-/// Add subscriber for signals
 impl Handler<Subscribe> for ProcessSignals {
     type Result = ();
 
@@ -200,8 +200,11 @@ impl Handler<Subscribe> for ProcessSignals {
     }
 }
 
-/// Default signals handler. This actor sends `SystemExit` message to `System`
-/// actor for each of `SIGINT`, `SIGTERM`, `SIGQUIT` signals.
+/// Default signals handler.
+///
+/// This actor sends the `SystemExit` message to the `System` actor
+/// for each of the following signals: `SIGINT`, `SIGTERM` and
+/// `SIGQUIT`.
 pub struct DefaultSignalsHandler;
 
 impl Default for DefaultSignalsHandler {
@@ -224,8 +227,8 @@ impl Actor for DefaultSignalsHandler {
     }
 }
 
-/// Handle `SIGINT`, `SIGTERM`, `SIGQUIT` signals and send `SystemExit(0)`
-/// message to `System` actor.
+/// Handle `SIGINT`, `SIGTERM`, `SIGQUIT` signals and send
+/// a `SystemExit(0)` message to the `System` actor.
 impl Handler<Signal> for DefaultSignalsHandler {
     type Result = ();
 

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -61,7 +61,7 @@ impl<A: Actor> fmt::Debug for AddressSender<A> {
     }
 }
 
-/// Weak referenced version of `AddressSender`
+/// A weakly referenced version of `AddressSender`.
 ///
 /// This is created by the `AddressSender::downgrade` method.
 pub struct WeakAddressSender<A: Actor> {
@@ -98,13 +98,13 @@ struct Inner<A: Actor> {
     // channel as well as a flag signalling that the channel is closed.
     state: AtomicUsize,
 
-    // Atomic, FIFO queue used to send messages to the receiver
+    // Atomic, FIFO queue used to send messages to the receiver.
     message_queue: Queue<Envelope<A>>,
 
     // Atomic, FIFO queue used to send parked task handles to the receiver.
     parked_queue: Queue<Arc<Mutex<SenderTask>>>,
 
-    // Number of senders in existence
+    // Number of senders in existence.
     num_senders: AtomicUsize,
 
     // Handle to the receiver's task.
@@ -231,7 +231,7 @@ impl<A: Actor> AddressSender<A> {
 
     /// Attempts to send a message on this `Sender<A>` with blocking.
     ///
-    /// This function, must be called from inside of a task.
+    /// This function must be called from inside of a task.
     pub fn send<M>(&self, msg: M) -> Result<Receiver<M::Result>, SendError<M>>
     where
         A: Handler<M>,
@@ -614,20 +614,20 @@ impl<A: Actor> AddressSenderProducer<A> {
 //
 //
 impl<A: Actor> AddressReceiver<A> {
-    /// Are any senders still connected
+    /// Returns whether any senders are still connected.
     pub fn connected(&self) -> bool {
         self.inner.num_senders.load(SeqCst) != 0
     }
 
-    /// Get channel capacity
+    /// Returns the channel capacity.
     pub fn capacity(&self) -> usize {
         self.inner.buffer.load(Relaxed)
     }
 
-    /// Set channel capacity
+    /// Sets the channel capacity.
     ///
-    /// This method wakes up all waiting senders if new capacity is greater
-    /// than current
+    /// This method wakes up all waiting senders if the new capacity
+    /// is greater than the current one.
     pub fn set_capacity(&mut self, cap: usize) {
         let buffer = self.inner.buffer.load(Relaxed);
         self.inner.buffer.store(cap, Relaxed);
@@ -652,7 +652,7 @@ impl<A: Actor> AddressReceiver<A> {
         }
     }
 
-    /// Get sender side of the channel
+    /// Returns the sender side of the channel.
     pub fn sender(&self) -> AddressSender<A> {
         // this code same as Sender::clone
         let mut curr = self.inner.num_senders.load(SeqCst);
@@ -680,7 +680,7 @@ impl<A: Actor> AddressReceiver<A> {
         }
     }
 
-    /// Create sender producer
+    /// Creates the sender producer.
     pub fn sender_producer(&self) -> AddressSenderProducer<A> {
         AddressSenderProducer {
             inner: self.inner.clone(),

--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -6,7 +6,7 @@ use actor::{Actor, AsyncContext};
 use context::Context;
 use handler::{Handler, Message, MessageResponse};
 
-/// Converter trait, packs message to suitable envelope
+/// Converter trait, packs message into a suitable envelope.
 pub trait ToEnvelope<A, M: Message>
 where
     A: Actor + Handler<M>,

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -11,9 +11,9 @@ use handler::{Handler, Message};
 use super::channel::{AddressSender, Sender};
 use super::{MailboxError, SendError, ToEnvelope};
 
-/// `Request` is a `Future` which represents asynchronous message sending
+/// A `Future` which represents an asynchronous message sending
 /// process.
-#[must_use = "You have to wait on request otherwise Message wont be delivered"]
+#[must_use = "You have to wait on request otherwise the Message wont be delivered"]
 pub struct Request<A, M>
 where
     A: Handler<M>,
@@ -101,8 +101,7 @@ where
     }
 }
 
-/// `RecipientRequest` is a `Future` which represents asynchronous message
-/// sending process.
+/// A `Future` which represents an asynchronous message sending process.
 #[must_use = "future do nothing unless polled"]
 pub struct RecipientRequest<M>
 where

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use contextimpl::{AsyncContextParts, ContextFut, ContextParts};
 use mailbox::Mailbox;
 
-/// Actor execution context
+/// An actor execution context.
 pub struct Context<A>
 where
     A: Actor<Context = Context<A>>,
@@ -114,16 +114,17 @@ where
         ContextFut::new(self, act, mb)
     }
 
-    /// Handle of the running future
+    /// Returns a handle to the running future.
     ///
-    /// SpawnHandle is the handle returned by `AsyncContext::spawn()` method.
+    /// This is the handle returned by the `AsyncContext::spawn()`
+    /// method.
     pub fn handle(&self) -> SpawnHandle {
         self.parts.curr_handle()
     }
 
-    /// Set mailbox capacity
+    /// Sets the mailbox capacity.
     ///
-    /// By default mailbox capacity is 16 messages.
+    /// The default mailbox capacity is 16 messages.
     pub fn set_mailbox_capacity(&mut self, cap: usize) {
         self.parts.set_mailbox_capacity(cap)
     }
@@ -138,17 +139,20 @@ where
     }
 }
 
-/// Helper trait which can spawn future into actor's context
+/// Helper trait which can spawn a future into the actor's context.
 pub trait ContextFutureSpawner<A>
 where
     A: Actor,
     A::Context: AsyncContext<A>,
 {
-    /// spawn future into `Context<A>`
+    /// Spawns the future into the given context.
     fn spawn(self, ctx: &mut A::Context);
 
-    /// Spawn future into the context. Stop processing any of incoming events
-    /// until this future resolves.
+    /// Spawns the future into the given context, waiting for it to
+    /// resolve.
+    ///
+    /// This stops processing any incoming events until this future
+    /// resolves.
     fn wait(self, ctx: &mut A::Context);
 }
 

--- a/src/fut/helpers.rs
+++ b/src/fut/helpers.rs
@@ -1,21 +1,21 @@
 use futures::{Async, Future, Poll, Stream};
 
-/// Helper trait that add helper method `finish()` to stream objects.
+/// Helper trait that adds the helper method `finish()` to stream objects.
 #[doc(hidden)]
 pub trait FinishStream: Sized {
     fn finish(self) -> Finish<Self>;
 }
 
 impl<S: Stream> FinishStream for S {
-    /// A combinator used to convert stream into a future, future resolves
-    /// when stream completes.
+    /// A combinator used to convert a stream into a future; the
+    /// future resolves when the stream completes.
     fn finish(self) -> Finish<S> {
         Finish::new(self)
     }
 }
 
-/// A combinator used to convert stream into a future, future resolves
-/// when stream completes.
+/// A combinator used to convert a stream into a future; the future
+/// resolves when the stream completes.
 ///
 /// This structure is produced by the `Stream::finish` method.
 #[derive(Debug)]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -8,49 +8,50 @@ use arbiter::Arbiter;
 use context::Context;
 use fut::{self, ActorFuture};
 
-/// Message handler
+/// A trait for objects which can handle messages of a specific type.
 ///
-/// `Handler` implementation is a general way how to handle
-/// incoming messages, streams, futures.
+/// Implementing `Handler` is a general way to handle incoming
+/// messages, streams, and futures.
 ///
-/// `M` is a message which can be handled by the actor.
+/// The type `M` is a message which can be handled by the actor.
 #[allow(unused_variables)]
 pub trait Handler<M>
 where
     Self: Actor,
     M: Message,
 {
-    /// The type of value that this handle will return
+    /// The type of value that this handler will return.
     type Result: MessageResponse<Self, M>;
 
-    /// Method is called for every message received by this Actor
+    /// This method is called for every message received by this actor.
     fn handle(&mut self, msg: M, ctx: &mut Self::Context) -> Self::Result;
 }
 
-/// Message type
+/// A trait for objects which represent messages that can be handled
+/// by an actor.
 pub trait Message {
     /// The type of value that this message will resolved with if it is
     /// successful.
     type Result: 'static;
 }
 
-/// Helper type that implements `MessageResponse` trait
+/// A helper type that implements the `MessageResponse` trait.
 pub struct MessageResult<M: Message>(pub M::Result);
 
-/// A specialized actor future for async message handler
+/// A specialized actor future for asynchronous message handling.
 pub type ResponseActFuture<A, I, E> = Box<ActorFuture<Item = I, Error = E, Actor = A>>;
 
-/// A specialized future for async message handler
+/// A specialized future for asynchronous message handling.
 pub type ResponseFuture<I, E> = Box<Future<Item = I, Error = E>>;
 
-/// Trait defines message response channel
+/// A trait that defines a message response channel.
 pub trait ResponseChannel<M: Message>: 'static {
     fn is_canceled(&self) -> bool;
 
     fn send(self, response: M::Result);
 }
 
-/// Trait which defines message response
+/// A trait which defines message responses.
 pub trait MessageResponse<A: Actor, M: Message> {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>);
 }
@@ -178,7 +179,7 @@ impl<I, E> fmt::Debug for Response<I, E> {
 }
 
 impl<I, E> Response<I, E> {
-    /// Create async response
+    /// Creates an asynchronous response.
     pub fn async<T>(fut: T) -> Self
     where
         T: Future<Item = I, Error = E> + 'static,
@@ -188,7 +189,7 @@ impl<I, E> Response<I, E> {
         }
     }
 
-    /// Create response
+    /// Creates a response.
     pub fn reply(val: Result<I, E>) -> Self {
         Response {
             item: ResponseTypeItem::Result(val),
@@ -226,7 +227,7 @@ enum ActorResponseTypeItem<A, I, E> {
     Fut(Box<ActorFuture<Item = I, Error = E, Actor = A>>),
 }
 
-/// Helper type for representing different type of message responses
+/// A helper type for representing different types of message responses.
 pub struct ActorResponse<A, I, E> {
     item: ActorResponseTypeItem<A, I, E>,
 }
@@ -242,14 +243,14 @@ impl<A, I, E> fmt::Debug for ActorResponse<A, I, E> {
 }
 
 impl<A: Actor, I, E> ActorResponse<A, I, E> {
-    /// Create response
+    /// Creates a response.
     pub fn reply(val: Result<I, E>) -> Self {
         ActorResponse {
             item: ActorResponseTypeItem::Result(val),
         }
     }
 
-    /// Create async response
+    /// Creates an asynchronous response.
     pub fn async<T>(fut: T) -> Self
     where
         T: ActorFuture<Item = I, Error = E, Actor = A> + 'static,

--- a/src/io.rs
+++ b/src/io.rs
@@ -11,7 +11,7 @@ use tokio_io::AsyncWrite;
 use actor::{Actor, ActorContext, AsyncContext, Running, SpawnHandle};
 use fut::ActorFuture;
 
-/// Write handler
+/// A helper trait for write handling.
 ///
 /// `WriteHandler` is a helper for `AsyncWrite` types. Implementation
 /// of this trait is required for `Writer` and `FramedWrite` support.
@@ -21,7 +21,7 @@ where
     Self: Actor,
     Self::Context: ActorContext,
 {
-    /// Method is called when writer emits error.
+    /// Called when the writer emits error.
     ///
     /// If this method returns `ErrorAction::Continue` writer processing
     /// continues otherwise stream processing stops.
@@ -29,7 +29,7 @@ where
         Running::Stop
     }
 
-    /// Method is called when writer finishes.
+    /// Called when the writer finishes.
     ///
     /// By default this method stops actor's `Context`.
     fn finished(&mut self, ctx: &mut Self::Context) {
@@ -47,7 +47,7 @@ bitflags! {
 const LOW_WATERMARK: usize = 4 * 1024;
 const HIGH_WATERMARK: usize = 4 * LOW_WATERMARK;
 
-/// Wrapper for `AsyncWrite` types
+/// A wrapper for `AsyncWrite` types.
 pub struct Writer<T: AsyncWrite, E: From<io::Error>> {
     inner: UnsafeWriter<T, E>,
 }
@@ -102,26 +102,26 @@ impl<T: AsyncWrite, E: From<io::Error> + 'static> Writer<T, E> {
         writer
     }
 
-    /// Gracefully close sink
+    /// Gracefully closes the sink.
     ///
-    /// Close process is asynchronous.
+    /// The closing happens asynchronously.
     pub fn close(&mut self) {
         self.inner.0.borrow_mut().flags.insert(Flags::CLOSING);
     }
 
-    /// Check if sink is closed
+    /// Checks if the sink is closed.
     pub fn closed(&self) -> bool {
         self.inner.0.borrow().flags.contains(Flags::CLOSED)
     }
 
-    /// Set write buffer capacity
+    /// Sets the write buffer capacity.
     pub fn set_buffer_capacity(&mut self, low_watermark: usize, high_watermark: usize) {
         let mut inner = self.inner.0.borrow_mut();
         inner.low = low_watermark;
         inner.high = high_watermark;
     }
 
-    /// Send item to a sink.
+    /// Sends an item to the sink.
     pub fn write(&mut self, msg: &[u8]) {
         let mut inner = self.inner.0.borrow_mut();
         inner.buffer.extend_from_slice(msg);
@@ -130,7 +130,7 @@ impl<T: AsyncWrite, E: From<io::Error> + 'static> Writer<T, E> {
         }
     }
 
-    /// `SpawnHandle` for this writer
+    /// Returns the `SpawnHandle` for this writer.
     pub fn handle(&self) -> SpawnHandle {
         self.inner.0.borrow().handle
     }
@@ -284,7 +284,7 @@ where
     }
 }
 
-/// Wrapper for `AsyncWrite` and `Encoder` types
+/// A wrapper for the `AsyncWrite` and `Encoder` types.
 pub struct FramedWrite<T: AsyncWrite, U: Encoder> {
     enc: U,
     inner: UnsafeWriter<T, U::Error>,
@@ -351,26 +351,26 @@ impl<T: AsyncWrite, U: Encoder> FramedWrite<T, U> {
         writer
     }
 
-    /// Gracefully close sink
+    /// Gracefully closes the sink.
     ///
-    /// Close process is asynchronous.
+    /// The closing happens asynchronously.
     pub fn close(&mut self) {
         self.inner.0.borrow_mut().flags.insert(Flags::CLOSING);
     }
 
-    /// Check if sink is closed
+    /// Checks if the sink is closed.
     pub fn closed(&self) -> bool {
         self.inner.0.borrow().flags.contains(Flags::CLOSED)
     }
 
-    /// Set write buffer capacity
+    /// Sets the write buffer capacity.
     pub fn set_buffer_capacity(&mut self, low: usize, high: usize) {
         let mut inner = self.inner.0.borrow_mut();
         inner.low = low;
         inner.high = high;
     }
 
-    /// Write item
+    /// Writes an item to the sink.
     pub fn write(&mut self, item: U::Item) {
         let mut inner = self.inner.0.borrow_mut();
         let _ = self.enc.encode(item, &mut inner.buffer).map_err(|e| {
@@ -381,7 +381,7 @@ impl<T: AsyncWrite, U: Encoder> FramedWrite<T, U> {
         }
     }
 
-    /// `SpawnHandle` for this writer
+    /// Returns the `SpawnHandle` for this writer.
     pub fn handle(&self) -> SpawnHandle {
         self.inner.0.borrow().handle
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
-//! # Actix is a rust actors framework.
+//! # Actix is a rust actors framework
 //!
-//! [Actors](https://actix.github.io/actix/actix/trait.Actor.html) are objects
-//! which encapsulate state and behavior, they communicate exclusively
-//! by exchanging messages. Actix actors are implemented on top of [Tokio](https://tokio.rs).
-//! Multiple actors could run in same thread. Actors could run in multiple
-//! threads with support of [`Arbiter`](https://actix.github.io/actix/actix/struct.Arbiter.html).
-//! Actors exchange typed messages.
+//! [Actors](https://actix.github.io/actix/actix/trait.Actor.html) are
+//! objects which encapsulate state and behavior, they communicate
+//! exclusively by exchanging messages. Actix actors are implemented
+//! on top of [Tokio](https://tokio.rs).  Multiple actors can run in
+//! same thread. Actors can run in multiple threads using the
+//! [`Arbiter`](struct.Arbiter.html) API. Actors exchange typed
+//! messages.
 //!
 //! ## Documentation
 //!
@@ -99,7 +100,7 @@ pub use actor::{
     Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
 };
 pub use address::{Addr, MailboxError, Recipient, WeakAddr};
-pub use arbiter::Arbiter;
+pub use arbiter::{Arbiter, ArbiterBuilder};
 pub use context::Context;
 pub use fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};
 pub use handler::{
@@ -116,7 +117,7 @@ pub use system::{System, SystemRunner};
 pub use context::ContextFutureSpawner;
 
 pub mod prelude {
-    //! The `actix` prelude
+    //! The `actix` prelude.
     //!
     //! The purpose of this module is to alleviate imports of many common actix
     //! traits by adding a glob import to the top of actix heavy modules:
@@ -157,7 +158,7 @@ pub mod prelude {
 }
 
 pub mod dev {
-    //! The `actix` prelude for library developers
+    //! The `actix` prelude for library developers.
     //!
     //! The purpose of this module is to alleviate imports of many common actix
     //! traits by adding a glob import to the top of actix heavy modules:
@@ -179,15 +180,16 @@ pub mod dev {
     pub use registry::{Registry, SystemRegistry};
 }
 
-/// Start the System and execute supplied future.
+/// Starts the system and executes the supplied future.
 ///
 /// This function does the following:
 ///
-/// * Creates and starts actix System with default configuration.
-/// * Spawn the given future onto the current arbiter.
-/// * Block the current thread until the system shuts down.
+/// * Creates and starts the actix system with default configuration.
+/// * Spawns the given future onto the current arbiter.
+/// * Blocks the current thread until the system shuts down.
 ///
-/// `run` functions returns when `System::current().stop()` method get called.
+/// The `run` function returns when the `System::current().stop()`
+/// method gets called.
 ///
 /// # Examples
 ///
@@ -210,7 +212,7 @@ pub mod dev {
 ///
 /// # Panics
 ///
-/// This function panics if actix system is already running.
+/// This function panics if the actix system is already running.
 pub fn run<F, R>(f: F)
 where
     F: FnOnce() -> R,
@@ -229,7 +231,7 @@ where
 ///
 /// # Panics
 ///
-/// This function panics if actix system is not running.
+/// This function panics if the actix system is not running.
 pub fn spawn<F>(f: F)
 where
     F: futures::Future<Item = (), Error = ()> + 'static,

--- a/src/msgs.rs
+++ b/src/msgs.rs
@@ -5,7 +5,7 @@ use address::Addr;
 use context::Context;
 use handler::Message;
 
-/// Stop arbiter execution
+/// Message to stop arbiter execution
 pub struct StopArbiter(pub i32);
 
 impl Message for StopArbiter {
@@ -47,9 +47,9 @@ impl<A: Actor, F: FnOnce() -> Addr<A> + Send + 'static> FnBox<A> for F {
     }
 }
 
-/// Execute function in arbiter's thread
+/// Message to execute a function in an arbiter's thread.
 ///
-/// Arbiter` actor handles Execute message.
+/// The arbiter actor handles `Execute` messages.
 ///
 /// # Example
 ///


### PR DESCRIPTION
This commit results from proof-reading the API docs throughout the
whole crate, excluding the `fut` module and its children.

Mostly, the changes are in the following areas:

- Use a consistent style, which is also used by the standard
  library, for example:

  - Using just "Registers ..." instead instead of "This method
    registers" for functions.

  - Use punctiation more consistently (no full stops in headings, but
    about everywhere else).

- Missing articles and other minor stylistic issues.

- Some markup issues (e.g. missing backticks for identifiers).

Besides mere wording improvements, which I hope are indeed
improvements (I'm not a native speaker, but dare to say that I'm quite
confident in English), the following tweaks also were made along the
way:

- Export the `Builder` type from the private `arbiter` module, after
  renaming it to `ArbiterBuilder`. Previously, this type was not
  directly visible from outside the crate, and thus also missing from
  `cargo doc` output.

- Adjust a few copy-pasted error strings in `AsyncContext`.