### PR TITLE
Bump trust-dns-proto to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix"
-version = "0.7.10"
+version = "0.7.11"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actor framework for Rust"
 readme = "README.md"
@@ -28,7 +28,7 @@ members = ["examples/chat"]
 default = ["signal", "resolver"]
 
 # dns resolver
-resolver = ["trust-dns-resolver", "trust-dns-proto"]
+resolver = ["trust-dns-resolver"]
 
 # signal handling
 signal = ["tokio-signal"]
@@ -64,7 +64,6 @@ uuid = { version = "0.7", features = ["v4"] }
 tokio-signal = { version = "0.2", optional = true }
 
 # dns resolver
-trust-dns-proto = { version = "^0.5.0", optional = true }
 trust-dns-resolver = { version = "^0.10.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
Currently actix ends up pulling both 0.5 and 0.6:
```
trust-dns-proto v0.5.0
└── actix v0.7.10 (/home/fabrice/dev/actix)

trust-dns-proto v0.6.3
└── trust-dns-resolver v0.10.3
    └── actix v0.7.10 (/home/fabrice/dev/actix)
```
Moving to 0.6 prevents that.