### PR TITLE
Improve documentation and examples for some functions.

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -230,13 +230,16 @@ impl ActorState {
 /// actor's communication channels (message handling).
 pub trait ActorContext: Sized {
     /// Immediately stop processing incoming messages and switch to a
-    /// `stopping` state
+    /// `stopping` state. This only affectrs actors that are currently
+    /// `running`. Future attempts to queue messages will fail.
     fn stop(&mut self);
 
-    /// Terminate actor execution
+    /// Terminate actor execution unconditionally. This sets the actor
+    /// into the `stopped` state. This causes future attempts to queue
+    /// messages to fail.
     fn terminate(&mut self);
 
-    /// Actor execution state
+    /// View the current Actor execution state.
     fn state(&self) -> ActorState;
 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -239,7 +239,7 @@ pub trait ActorContext: Sized {
     /// messages to fail.
     fn terminate(&mut self);
 
-    /// Get or retrieve the current Actor execution state.
+    /// Retrieve the current Actor execution state.
     fn state(&self) -> ActorState;
 }
 

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -230,7 +230,7 @@ impl ActorState {
 /// actor's communication channels (message handling).
 pub trait ActorContext: Sized {
     /// Immediately stop processing incoming messages and switch to a
-    /// `stopping` state. This only affectrs actors that are currently
+    /// `stopping` state. This only affects actors that are currently
     /// `running`. Future attempts to queue messages will fail.
     fn stop(&mut self);
 
@@ -239,7 +239,7 @@ pub trait ActorContext: Sized {
     /// messages to fail.
     fn terminate(&mut self);
 
-    /// View the current Actor execution state.
+    /// Get or retrieve the current Actor execution state.
     fn state(&self) -> ActorState;
 }
 
@@ -381,7 +381,9 @@ where
         }
     }
 
-    /// Sends the message `msg` to self.
+    /// Sends the message `msg` to self. This bypasses the mailbox capacity, and
+    /// will always queue the message. If the actor is in the `stopped` state, an
+    /// error will be raised.
     fn notify<M>(&mut self, msg: M)
     where
         A: Handler<M>,
@@ -398,7 +400,9 @@ where
     ///
     /// Returns a spawn handle which can be used for cancellation. The
     /// notification gets cancelled if the context's stop method gets
-    /// called.
+    /// called. This bypasses the mailbox capacity, and
+    /// will always queue the message. If the actor is in the `stopped` state, an
+    /// error will be raised.
     fn notify_later<M>(&mut self, msg: M, after: Duration) -> SpawnHandle
     where
         A: Handler<M>,

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -306,6 +306,9 @@ impl<A: Actor> AddressSender<A> {
         if self.inc_num_messages().is_none() {
             Err(SendError::Closed(msg))
         } else {
+            // If inc_num_messages returned Some(park_self), then the mailbox is still active.
+            // We ignore the boolean (indicating to park and wait) in the Some, and queue the
+            // message regardless.
             let env = <A::Context as ToEnvelope<A, M>>::pack(msg, None);
             self.queue_push_and_signal(env);
             Ok(())

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -82,7 +82,7 @@ impl<A: Actor> Addr<A> {
     }
 
     #[inline]
-    /// Sends a message unconditionally, ignoring any faults that occur.
+    /// Sends a message unconditionally, ignoring any potential errors.
     ///
     /// The message is always queued, even if the mailbox for the receiver is full.
     /// If the mailbox is closed, the message is silently dropped.

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -82,10 +82,10 @@ impl<A: Actor> Addr<A> {
     }
 
     #[inline]
-    /// Sends a message unconditionally.
+    /// Sends a message unconditionally, ignoring any faults that occur.
     ///
-    /// This method ignores actor's mailbox capacity, and silently
-    /// fails if the mailbox is closed.
+    /// The message is always queued, even if the mailbox for the receiver is full.
+    /// If the mailbox is closed, the message is silently dropped.
     pub fn do_send<M>(&self, msg: M)
     where
         M: Message + Send,

--- a/src/context.rs
+++ b/src/context.rs
@@ -125,6 +125,24 @@ where
     /// Sets the mailbox capacity.
     ///
     /// The default mailbox capacity is 16 messages.
+    /// #Examples
+    /// ```
+    /// # extern crate actix;
+    /// # use actix::prelude::*;
+    /// struct MyActor;
+    /// impl Actor for MyActor {
+    ///     type Context = Context<Self>;
+    ///
+    ///     fn started(&mut self, ctx: &mut Self::Context) {
+    ///         ctx.set_mailbox_capacity(1);
+    ///     }
+    /// }
+    ///
+    /// # fn main() {
+    /// # System::new("test");
+    /// let addr = MyActor.start();
+    /// # }
+    /// ```
     pub fn set_mailbox_capacity(&mut self, cap: usize) {
         self.parts.set_mailbox_capacity(cap)
     }


### PR DESCRIPTION
This change improves the examples for setting mailbox capacity,
it improves the documentation of stop and terminate, and adds
some extra comments for clarity in do_send.

Author: William Brown <william@blackhats.net.au>