### PR TITLE
Fix compiler warning because of doc comment in the wrong place

### DIFF
--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -10,14 +10,14 @@ use contextitems::ActorWaitItem;
 use fut::ActorFuture;
 use mailbox::Mailbox;
 
-/// internal context state
 bitflags! {
-    pub struct ContextFlags: u8 {
-        const STARTED =  0b0000_0001;
-        const RUNNING =  0b0000_0010;
-        const STOPPING = 0b0000_0100;
-        const STOPPED =  0b0001_0000;
-        const MB_CAP_CHANGED = 0b0010_0000;
+    /// internal context state
+    struct ContextFlags: u8 {
+    const STARTED =  0b0000_0001;
+    const RUNNING =  0b0000_0010;
+    const STOPPING = 0b0000_0100;
+    const STOPPED =  0b0001_0000;
+    const MB_CAP_CHANGED = 0b0010_0000;
     }
 }
 


### PR DESCRIPTION
Recently rustdoc started issuing compiler warnings for doc comments above macro expansions. Moving this comment inside the macro resolves that. However, this comment still doesn't show up in the documentation, because the struct in question is not publicly reachable. 

So for consistency I remove the pub. As an alternative, it might be `pub( crate )`. Please modify to your liking.

`cargo test --all-features` runs fine. As some extra test I thought I run all tests on actix-web as well, but I can't get actix-web to compile with a local actix, so ... dunno... 

ps: I'm using nightly compiler