### PR TITLE
Add derive tests for MessageResponse

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ signal = ["tokio-signal"]
 mailbox_assert = []
 
 [dependencies]
-actix_derive = "0.3"
+actix_derive = "0.4"
 
 # io
 bytes = "0.4"


### PR DESCRIPTION
Related: https://github.com/actix/actix-derive/pull/14

Awaiting new release of actix-derive before CI tests can pass. I've ran tests using a path dependency to a local clone of actix-derive to make sure the tests pass.