### PR TITLE
examples chat: Switch to 2018 edition

### DIFF
--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -3,6 +3,7 @@ name = "chat"
 version = "0.1.0"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 workspace = "../../"
+edition = "2018"
 
 [[bin]]
 name = "server"

--- a/examples/chat/src/client.rs
+++ b/examples/chat/src/client.rs
@@ -1,16 +1,3 @@
-#[macro_use]
-extern crate actix;
-extern crate byteorder;
-extern crate bytes;
-extern crate futures;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_codec;
-extern crate tokio_io;
-extern crate tokio_tcp;
-#[macro_use]
-extern crate serde_derive;
-
 use std::str::FromStr;
 use std::time::Duration;
 use std::{io, net, process, thread};

--- a/examples/chat/src/codec.rs
+++ b/examples/chat/src/codec.rs
@@ -1,6 +1,8 @@
 #![allow(dead_code)]
+use actix::Message;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::{BufMut, BytesMut};
+use serde_derive::{Serialize, Deserialize};
 use serde_json as json;
 use std::io;
 use tokio_io::codec::{Decoder, Encoder};

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -1,18 +1,4 @@
 #![cfg_attr(feature = "cargo-clippy", allow(let_unit_value))]
-extern crate byteorder;
-extern crate bytes;
-extern crate futures;
-extern crate rand;
-extern crate serde;
-extern crate serde_json;
-extern crate tokio_io;
-extern crate tokio_tcp;
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern crate actix;
-
 use std::net;
 use std::str::FromStr;
 

--- a/examples/chat/src/server.rs
+++ b/examples/chat/src/server.rs
@@ -6,7 +6,7 @@ use actix::prelude::*;
 use rand::{self, Rng};
 use std::collections::{HashMap, HashSet};
 
-use session;
+use crate::session;
 
 /// Message for chat server communications
 

--- a/examples/chat/src/session.rs
+++ b/examples/chat/src/session.rs
@@ -6,8 +6,8 @@ use std::time::{Duration, Instant};
 use tokio_io::io::WriteHalf;
 use tokio_tcp::TcpStream;
 
-use codec::{ChatCodec, ChatRequest, ChatResponse};
-use server::{self, ChatServer};
+use crate::codec::{ChatCodec, ChatRequest, ChatResponse};
+use crate::server::{self, ChatServer};
 
 /// Chat server sends this messages to session
 #[derive(Message)]


### PR DESCRIPTION
This allows eliminating all the `extern crate` statements from the
chat example source code.