### PR TITLE
Eliminate `extern crate` statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ actix = "0.7"
 In order to use actix you first need to create a `System`.
 
 ```rust,ignore
-extern crate actix;
-
 fn main() {
     let system = actix::System::new("test");
 
@@ -57,7 +55,6 @@ the [`Actor`](https://actix.github.io/actix/actix/trait.Actor.html) trait.
 
 
 ```rust
-extern crate actix;
 use actix::{msgs, Actor, Addr, Arbiter, Context, System};
 
 struct MyActor;
@@ -95,8 +92,6 @@ are typed. Let's define a simple `Sum` message with two `usize` parameters,
 and an actor which will accept this message and return the sum of those two numbers.
 
 ```rust
-extern crate actix;
-extern crate futures;
 use futures::{future, Future};
 use actix::*;
 
@@ -158,7 +153,6 @@ an actor that can handle the message, we can use the `Recipient` interface. Let'
 a new actor that uses `Recipient`.
 
 ```rust
-#[macro_use] extern crate actix;
 use std::time::Duration;
 use actix::prelude::*;
 

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -6,9 +6,6 @@
  * message round the ring M times so that a total of N * M messages
  * get sent. Time how long this takes for different values of N and M."
  */
-extern crate actix;
-extern crate futures;
-
 use actix::*;
 
 use std::env;

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use actix_rt::Arbiter;
 use futures::Stream;
+use log::error;
 
 use crate::address::{channel, Addr};
 use crate::context::Context;
@@ -308,8 +309,6 @@ where
     /// actor messages.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate actix;
-    /// # extern crate futures;
     /// # use std::io;
     /// use actix::prelude::*;
     /// use futures::stream::once;
@@ -359,8 +358,6 @@ where
     /// errors.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate actix;
-    /// # extern crate futures;
     /// use actix::prelude::*;
     /// use futures::stream::once;
     ///

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -45,6 +45,7 @@ use std::time::Duration;
 
 use derive_more::Display;
 use futures::{Async, Future, Poll};
+use log::warn;
 use tokio_tcp::{ConnectFuture, TcpStream};
 use tokio_timer::Delay;
 use trust_dns_resolver::config::{ResolverConfig, ResolverOpts};

--- a/src/context.rs
+++ b/src/context.rs
@@ -126,7 +126,6 @@ where
     /// The default mailbox capacity is 16 messages.
     /// #Examples
     /// ```
-    /// # extern crate actix;
     /// # use actix::prelude::*;
     /// struct MyActor;
     /// impl Actor for MyActor {

--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use futures::{Async, Future, Poll};
 use smallvec::SmallVec;
 use std::fmt;

--- a/src/fut/stream_and_then.rs
+++ b/src/fut/stream_and_then.rs
@@ -1,4 +1,4 @@
-use futures::{Async, Poll};
+use futures::{try_ready, Async, Poll};
 
 use crate::actor::Actor;
 use crate::fut::{ActorFuture, ActorStream, IntoActorFuture};

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::marker::PhantomData;
 use std::rc::Rc;
 
+use bitflags::bitflags;
 use bytes::BytesMut;
 use futures::sink::Sink;
 use futures::{task, Async, AsyncSink, Poll, StartSend};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,18 +40,6 @@
 //! in `current_thread`
 //! - `Stdin`, `Stderr` and `Stdout` from `tokio::io` are the same as file I/O in that regard and
 //! cannot be used in asynchronous manner in actix.
-#[macro_use]
-extern crate bitflags;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate futures;
-
-#[cfg_attr(feature = "cargo-clippy", allow(useless_attribute))]
-#[allow(unused_imports)]
-#[macro_use]
-extern crate actix_derive;
-
 #[doc(hidden)]
 pub use actix_derive::*;
 
@@ -175,9 +163,6 @@ pub mod dev {
 /// # Examples
 ///
 /// ```
-/// # extern crate actix;
-/// # extern crate tokio_timer;
-/// # extern crate futures;
 /// # use futures::Future;
 /// use std::time::{Duration, Instant};
 /// use tokio_timer::Delay;

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -30,7 +30,6 @@ type AnyMap = HashMap<TypeId, Box<Any>>;
 /// # Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate actix;
 /// use actix::prelude::*;
 ///
 /// #[derive(Message)]
@@ -170,7 +169,6 @@ impl Registry {
 /// # Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate actix;
 /// use actix::prelude::*;
 ///
 /// #[derive(Message)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -1,4 +1,5 @@
 use futures::{Async, Poll, Stream};
+use log::error;
 use std::marker::PhantomData;
 
 use crate::actor::{
@@ -47,8 +48,6 @@ where
     /// allows to handle `Stream` in similar way as normal actor messages.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate actix;
-    /// # extern crate futures;
     /// # use std::io;
     /// use actix::prelude::*;
     /// use futures::stream::once;

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -25,7 +25,6 @@ use crate::mailbox::DEFAULT_CAPACITY;
 /// ## Example
 ///
 /// ```rust
-/// # #[macro_use] extern crate actix;
 /// # use actix::prelude::*;
 /// #[derive(Message)]
 /// struct Die;
@@ -79,7 +78,6 @@ where
     /// _>` type as type of a variable.
     ///
     /// ```rust
-    /// # #[macro_use] extern crate actix;
     /// # use actix::prelude::*;
     /// struct MyActor;
     ///

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -14,6 +14,7 @@ use actix_rt::System;
 use crossbeam_channel as cb_channel;
 use futures::sync::oneshot::Sender as SyncSender;
 use futures::{Async, Future, Poll, Stream};
+use log::warn;
 
 use crate::actor::{Actor, ActorContext, ActorState, Running};
 use crate::address::channel;
@@ -33,8 +34,6 @@ use crate::handler::{Handler, Message, MessageResponse};
 /// ## Example
 ///
 /// ```rust
-/// # extern crate actix;
-/// # extern crate futures;
 /// use actix::prelude::*;
 ///
 /// struct Fibonacci(pub u32);
@@ -195,8 +194,6 @@ where
 /// ## Example
 ///
 /// ```rust
-/// # extern crate actix;
-/// # extern crate futures;
 /// use actix::prelude::*;
 ///
 /// # struct Fibonacci(pub u32);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -50,8 +50,6 @@ where
 /// [`Context::run_later`]: ../prelude/trait.AsyncContext.html#method.run_later
 ///
 /// ```rust
-/// # #[macro_use] extern crate actix;
-/// # extern crate futures;
 /// # use std::io;
 /// use std::time::Duration;
 /// use actix::prelude::*;
@@ -149,8 +147,6 @@ where
 /// [`Context::run_interval`]: ../prelude/trait.AsyncContext.html#method.run_interval
 ///
 /// ```rust
-/// # #[macro_use] extern crate actix;
-/// # extern crate futures;
 /// # use std::io;
 /// use std::time::Duration;
 /// use actix::prelude::*;

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate actix;
-
 use actix::prelude::*;
 use futures::future;
 use std::ops::Mul;

--- a/tests/test_fut.rs
+++ b/tests/test_fut.rs
@@ -1,7 +1,3 @@
-extern crate actix;
-extern crate futures;
-extern crate tokio_timer;
-
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};

--- a/tests/test_sink.rs
+++ b/tests/test_sink.rs
@@ -1,7 +1,3 @@
-extern crate actix;
-extern crate bytes;
-extern crate futures;
-
 use actix::io::SinkWrite;
 use actix::prelude::*;
 use bytes::Bytes;

--- a/tests/test_sync.rs
+++ b/tests/test_sync.rs
@@ -1,7 +1,3 @@
-extern crate actix;
-extern crate futures;
-extern crate tokio_timer;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 


### PR DESCRIPTION
These are no longer needed in the 2018 edition, and their `macro_use`
variants can be replaced with explicitly importing the macros needed.