### PR TITLE
examples chat: Fix warnings

### DIFF
--- a/examples/chat/src/client.rs
+++ b/examples/chat/src/client.rs
@@ -11,7 +11,7 @@ use tokio_tcp::TcpStream;
 
 mod codec;
 
-fn main() {
+fn main() -> std::io::Result<()> {
     println!("Running chat client");
 
     actix::System::run(|| {
@@ -50,7 +50,7 @@ fn main() {
                     process::exit(1)
                 }),
         );
-    });
+    })
 }
 
 struct ChatClient {

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use actix::prelude::*;
 use futures::Stream;
-use tokio_io::codec::FramedRead;
+use tokio_codec::FramedRead;
 use tokio_io::AsyncRead;
 use tokio_tcp::{TcpListener, TcpStream};
 
@@ -49,7 +49,7 @@ impl Handler<TcpConnect> for Server {
     }
 }
 
-fn main() {
+fn main() -> std::io::Result<()> {
     actix::System::run(|| {
         // Start chat server actor
         let server = ChatServer::default().start();
@@ -72,5 +72,5 @@ fn main() {
         });
 
         println!("Running chat server on 127.0.0.1:12345");
-    });
+    })
 }


### PR DESCRIPTION
- `tokio_io::codec::FramedRead` is a deprecated alias to
  `tokio_codec::FramedRead`.

- No longer ignore the `Result` returned by `actix::System::run()`.