### PR TITLE
Add `std::error::Error` implementation for `MailboxError`

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -1,5 +1,5 @@
 use derive_more::Display;
-use std::fmt;
+use std::{error, fmt};
 use std::hash::{Hash, Hasher};
 
 pub(crate) mod channel;
@@ -29,6 +29,8 @@ pub enum MailboxError {
     #[display(fmt = "Message delivery timed out")]
     Timeout,
 }
+
+impl error::Error for MailboxError {}
 
 impl<T> SendError<T> {
     pub fn into_inner(self) -> T {


### PR DESCRIPTION
Since `MailboxError` does not have an underlying error which caused
it, and the `std::error::Error::description()` method is
soft-deprecated ("new `impl`s can omit it", to quote the standard
library), an empty implementation suffices.