### PR TITLE
examples chat: Add signal handling in server

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,8 +32,11 @@
 
 ### Deleted
 
-* Deleted signals actor
+* Deleted signals actor. The functionality formerly provided by the
+  signals actor can be achieved using the `tokio-signal` crate. See
+  the [chat example] for how this can work.
 
+  [chat example]: ./examples/chat/src/main.rs
 
 ## [0.7.10] (2019-01-16)
 

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -21,6 +21,7 @@ futures = "0.1"
 tokio-codec = "0.1"
 tokio-io = "0.1"
 tokio-tcp = "0.1"
+tokio-signal = "0.2"
 
 serde = "1.0"
 serde_json = "1.0"

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -71,6 +71,14 @@ fn main() -> std::io::Result<()> {
             Server { chat: server }
         });
 
+        let ctrl_c = tokio_signal::ctrl_c().flatten_stream();
+        let handle_shutdown = ctrl_c.for_each(|()| {
+            println!("Ctrl-C received, shutting down");
+            System::current().stop();
+            Ok(())
+        }).map_err(|_| ());
+        actix::spawn(handle_shutdown);
+
         println!("Running chat server on 127.0.0.1:12345");
     })
 }


### PR DESCRIPTION
This also serves as an example of how to replace the functionality of
the removed signal actor. An appropriate reference in `CHANGES.md` is
added.