### PR TITLE
Fix few clippy warnings

### DIFF
--- a/src/fut/mod.rs
+++ b/src/fut/mod.rs
@@ -304,7 +304,7 @@ pub trait ActorStream {
 /// used in a very similar fashion.
 pub trait IntoActorFuture {
     /// The future that this type can be converted into.
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     type Future: ActorFuture<Item=Self::Item, Error=Self::Error, Actor=Self::Actor>;
 
     /// The item that the future may resolve with.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,7 +108,7 @@ trait TimerFuncBox<A: Actor>: 'static {
 }
 
 impl<A: Actor, F: FnOnce(&mut A, &mut A::Context) + 'static> TimerFuncBox<A> for F {
-    #[cfg_attr(feature = "cargo-clippy", allow(boxed_local))]
+    #[allow(clippy::boxed_local)]
     fn call(self: Box<Self>, act: &mut A, ctx: &mut A::Context) {
         (*self)(act, ctx)
     }
@@ -201,7 +201,7 @@ trait IntervalFuncBox<A: Actor>: 'static {
 }
 
 impl<A: Actor, F: FnMut(&mut A, &mut A::Context) + 'static> IntervalFuncBox<A> for F {
-    #[cfg_attr(feature = "cargo-clippy", allow(boxed_local))]
+    #[allow(clippy::boxed_local)]
     fn call(&mut self, act: &mut A, ctx: &mut A::Context) {
         self(act, ctx)
     }


### PR DESCRIPTION
Use `rustfmt` and `clippy` prefixes.