### PR TITLE
Fix clippy warnings

### DIFF
--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(let_unit_value))]
+#![allow(clippy::let_unit_value)]
 use std::net;
 use std::str::FromStr;
 

--- a/src/actors/mocker.rs
+++ b/src/actors/mocker.rs
@@ -37,12 +37,12 @@ use crate::prelude::*;
 /// the actor.
 pub struct Mocker<T: Sized + 'static> {
     phantom: PhantomData<T>,
-    mock: Box<FnMut(Box<Any>, &mut Context<Mocker<T>>) -> Box<Any>>,
+    mock: Box<dyn FnMut(Box<dyn Any>, &mut Context<Mocker<T>>) -> Box<dyn Any>>,
 }
 
 impl<T> Mocker<T> {
     pub fn mock(
-        mock: Box<FnMut(Box<Any>, &mut Context<Mocker<T>>) -> Box<Any>>,
+        mock: Box<dyn FnMut(Box<dyn Any>, &mut Context<Mocker<T>>) -> Box<dyn Any>>,
     ) -> Mocker<T> {
         Mocker::<T> {
             phantom: PhantomData,

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -30,7 +30,7 @@ where
 
     fn send(&self, msg: M) -> Result<Receiver<M::Result>, SendError<M>>;
 
-    fn boxed(&self) -> Box<Sender<M>>;
+    fn boxed(&self) -> Box<dyn Sender<M>>;
 
     fn hash(&self) -> usize;
 
@@ -456,7 +456,7 @@ where
     fn send(&self, msg: M) -> Result<Receiver<M::Result>, SendError<M>> {
         self.send(msg)
     }
-    fn boxed(&self) -> Box<Sender<M>> {
+    fn boxed(&self) -> Box<dyn Sender<M>> {
         Box::new(self.clone())
     }
 

--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -38,7 +38,7 @@ where
     }
 }
 
-pub struct Envelope<A: Actor>(Box<EnvelopeProxy<Actor = A> + Send>);
+pub struct Envelope<A: Actor>(Box<dyn EnvelopeProxy<Actor = A> + Send>);
 
 impl<A: Actor> Envelope<A> {
     pub fn new<M>(msg: M, tx: Option<Sender<M::Result>>) -> Self
@@ -55,7 +55,7 @@ impl<A: Actor> Envelope<A> {
         }))
     }
 
-    pub fn with_proxy(proxy: Box<EnvelopeProxy<Actor = A> + Send>) -> Self {
+    pub fn with_proxy(proxy: Box<dyn EnvelopeProxy<Actor = A> + Send>) -> Self {
         Envelope(proxy)
     }
 }

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -110,7 +110,7 @@ where
     M::Result: Send,
 {
     rx: Option<oneshot::Receiver<M::Result>>,
-    info: Option<(Box<Sender<M>>, M)>,
+    info: Option<(Box<dyn Sender<M>>, M)>,
     timeout: Option<Delay>,
 }
 
@@ -121,7 +121,7 @@ where
 {
     pub fn new(
         rx: Option<oneshot::Receiver<M::Result>>,
-        info: Option<(Box<Sender<M>>, M)>,
+        info: Option<(Box<dyn Sender<M>>, M)>,
     ) -> RecipientRequest<M> {
         RecipientRequest {
             rx,

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -211,7 +211,7 @@ where
     M: Message + Send,
     M::Result: Send,
 {
-    tx: Box<Sender<M>>,
+    tx: Box<dyn Sender<M>>,
 }
 
 impl<M> Recipient<M>
@@ -220,7 +220,7 @@ where
     M::Result: Send,
 {
     /// Creates a new recipient.
-    pub(crate) fn new(tx: Box<Sender<M>>) -> Recipient<M> {
+    pub(crate) fn new(tx: Box<dyn Sender<M>>) -> Recipient<M> {
         Recipient { tx }
     }
 

--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -24,7 +24,7 @@ bitflags! {
 
 type Item<A> = (
     SpawnHandle,
-    Box<ActorFuture<Item = (), Error = (), Actor = A>>,
+    Box<dyn ActorFuture<Item = (), Error = (), Actor = A>>,
 );
 
 pub trait AsyncContextParts<A>: ActorContext + AsyncContext<A>
@@ -133,7 +133,7 @@ where
     {
         let handle = self.handles[0].next();
         self.handles[0] = handle;
-        let fut: Box<ActorFuture<Item = (), Error = (), Actor = A>> = Box::new(fut);
+        let fut: Box<dyn ActorFuture<Item = (), Error = (), Actor = A>> = Box::new(fut);
         self.items.push((handle, fut));
         handle
     }

--- a/src/contextitems.rs
+++ b/src/contextitems.rs
@@ -9,7 +9,7 @@ use crate::fut::ActorFuture;
 use crate::handler::{Handler, Message, MessageResponse};
 
 pub(crate) struct ActorWaitItem<A: Actor>(
-    Box<ActorFuture<Item = (), Error = (), Actor = A>>,
+    Box<dyn ActorFuture<Item = (), Error = (), Actor = A>>,
 );
 
 impl<A> ActorWaitItem<A>

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -54,10 +54,11 @@ where
 pub struct MessageResult<M: Message>(pub M::Result);
 
 /// A specialized actor future for asynchronous message handling.
-pub type ResponseActFuture<A, I, E> = Box<ActorFuture<Item = I, Error = E, Actor = A>>;
+pub type ResponseActFuture<A, I, E> =
+    Box<dyn ActorFuture<Item = I, Error = E, Actor = A>>;
 
 /// A specialized future for asynchronous message handling.
-pub type ResponseFuture<I, E> = Box<Future<Item = I, Error = E>>;
+pub type ResponseFuture<I, E> = Box<dyn Future<Item = I, Error = E>>;
 
 /// A trait that defines a message response channel.
 pub trait ResponseChannel<M: Message>: 'static {
@@ -187,7 +188,7 @@ where
 
 enum ResponseTypeItem<I, E> {
     Result(Result<I, E>),
-    Fut(Box<Future<Item = I, Error = E>>),
+    Fut(Box<dyn Future<Item = I, Error = E>>),
 }
 
 /// Helper type for representing different type of message responses
@@ -252,7 +253,7 @@ where
 
 enum ActorResponseTypeItem<A, I, E> {
     Result(Result<I, E>),
-    Fut(Box<ActorFuture<Item = I, Error = E, Actor = A>>),
+    Fut(Box<dyn ActorFuture<Item = I, Error = E, Actor = A>>),
 }
 
 /// A helper type for representing different types of message responses.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -17,7 +17,7 @@ use crate::address::Addr;
 use crate::context::Context;
 use crate::supervisor::Supervisor;
 
-type AnyMap = HashMap<TypeId, Box<Any>>;
+type AnyMap = HashMap<TypeId, Box<dyn Any>>;
 
 /// Actors registry
 ///
@@ -219,7 +219,7 @@ impl Registry {
 #[derive(Debug)]
 pub struct SystemRegistry {
     system: Arbiter,
-    registry: HashMap<TypeId, Box<Any + Send>>,
+    registry: HashMap<TypeId, Box<dyn Any + Send>>,
 }
 
 lazy_static::lazy_static! {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -220,14 +220,17 @@ where
     queue: cb_channel::Receiver<Envelope<A>>,
     stopping: bool,
     state: ActorState,
-    factory: Arc<Fn() -> A>,
+    factory: Arc<dyn Fn() -> A>,
 }
 
 impl<A> SyncContext<A>
 where
     A: Actor<Context = Self>,
 {
-    fn new(factory: Arc<Fn() -> A>, queue: cb_channel::Receiver<Envelope<A>>) -> Self {
+    fn new(
+        factory: Arc<dyn Fn() -> A>,
+        queue: cb_channel::Receiver<Envelope<A>>,
+    ) -> Self {
         let act = factory();
         Self {
             queue,

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -83,7 +83,7 @@ pub struct TimerFunc<A>
 where
     A: Actor,
 {
-    f: Option<Box<TimerFuncBox<A>>>,
+    f: Option<Box<dyn TimerFuncBox<A>>>,
     timeout: Delay,
 }
 
@@ -179,7 +179,7 @@ where
 /// ```
 #[must_use = "future do nothing unless polled"]
 pub struct IntervalFunc<A: Actor> {
-    f: Box<IntervalFuncBox<A>>,
+    f: Box<dyn IntervalFuncBox<A>>,
     interval: Interval,
 }
 


### PR DESCRIPTION
Add explicit `dyn`s and rename lint attribute