### PR TITLE
SystemRegistry refactor

### DIFF
--- a/tests/test_system_registry.rs
+++ b/tests/test_system_registry.rs
@@ -1,0 +1,50 @@
+use actix::prelude::*;
+use actix::SystemRegistry;
+
+#[derive(Default)]
+struct MyActor;
+
+impl Actor for MyActor {
+    type Context = Context<Self>;
+}
+
+impl SystemService for MyActor {}
+
+impl Supervised for MyActor {}
+
+#[test]
+#[should_panic(expected = "Actor already started")]
+fn test_unchecked_set_panics() {
+    System::run(|| {
+        let arbiter = Arbiter::new();
+
+        let addr = MyActor::start_default();
+
+        SystemRegistry::set(addr);
+
+        let addr = MyActor::from_registry();
+
+        SystemRegistry::set(addr);
+
+        System::current().stop();
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_checked_set_does_not_panic() {
+    System::run(|| {
+        let arbiter = Arbiter::new();
+
+        let addr = MyActor::start_default();
+
+        SystemRegistry::set(addr);
+
+        let addr = MyActor::from_registry();
+
+        SystemRegistry::set_checked(addr);
+
+        System::current().stop();
+    })
+    .unwrap()
+}


### PR DESCRIPTION
Changes to `SystemRegistry`:

- Added `set_checked` function that does not panic if the actor is already present in the registry.
- Removed redundant `get` function.
- Changed `query` to not be a public function as there is currently no way for users to access it.
- Added local `apply_set` function to reduce code repetition.
- Added some integration tests for `set` and `set_checked` 