### PR TITLE
Update type signature for ResponseFuture to match BoxFuture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## [0.9.0-alpha.3] 2019-12-16
+
+### Fixed
+
+* Fix `ResolveFuture` type signature.
+
 ## [0.9.0-alpha.2] 2019-12-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actix"
-version = "0.9.0-alpha.2"
+version = "0.9.0-alpha.3"
 authors = ["Nikolay Kim <fafhrd91@gmail.com>"]
 description = "Actor framework for Rust"
 readme = "README.md"

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use futures::channel::oneshot::Sender as SyncSender;
@@ -59,7 +60,7 @@ pub struct MessageResult<M: Message>(pub M::Result);
 pub type ResponseActFuture<A, I> = Box<dyn ActorFuture<Output = I, Actor = A>>;
 
 /// A specialized future for asynchronous message handling.
-pub type ResponseFuture<I> = Box<dyn Future<Output = I> + Unpin>;
+pub type ResponseFuture<I> = Pin<Box<dyn Future<Output = I>>>;
 
 /// A trait that defines a message response channel.
 pub trait ResponseChannel<M: Message>: 'static {


### PR DESCRIPTION
The type signature for `ResponseFuture` was causing issues with `Unpin` and `GenFuture`. 