### PR TITLE
Fix broken Ring example

### DIFF
--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -51,8 +51,9 @@ fn print_usage_and_exit() -> ! {
     ::std::process::exit(1);
 }
 
-#[actix_rt::main]
-async fn main() {
+fn main() -> std::io::Result<()> {
+    let system = System::new("ring");
+
     let args = env::args().collect::<Vec<_>>();
     if args.len() < 3 {
         print_usage_and_exit();
@@ -101,7 +102,9 @@ async fn main() {
             next: prev_addr.recipient(),
         }
     });
-    node.send(Payload(0)).await.unwrap();
+
+    let _req = node.send(Payload(1));
+    system.run();
 
     match now.elapsed() {
         Ok(elapsed) => println!(
@@ -111,4 +114,6 @@ async fn main() {
         ),
         Err(e) => println!("An error occured: {:?}", e),
     }
+
+    Ok(())
 }

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -33,9 +33,12 @@ impl Handler<Payload> for Node {
 
     fn handle(&mut self, msg: Payload, _: &mut Context<Self>) {
         if msg.0 >= self.limit {
-            println!("Reached limit of {} (payload was {})", self.limit, msg.0);
+            println!("Actor {} reached limit of {} (payload was {})", self.id, self.limit, msg.0);
             System::current().stop();
             return;
+        }
+        if msg.0 % 498989 == 1 { // prime
+            println!("Actor {} received message {} of {} ({:.2}%)", self.id, msg.0, self.limit, 100.0 * msg.0 as f32 / self.limit as f32);
         }
         self.next
             .do_send(Payload(msg.0 + 1))

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -76,7 +76,7 @@ fn main() -> std::io::Result<()> {
 
     let setup = SystemTime::now();
 
-    println!("Setting up nodes");
+    println!("Setting up {} nodes", n_nodes);
     let limit = n_nodes * n_times;
     let node = Node::create(move |ctx| {
         let first_addr = ctx.address();
@@ -115,13 +115,17 @@ fn main() -> std::io::Result<()> {
     let now = SystemTime::now();
 
     let _req = node.send(Payload(1));
-    system.run();
+
+    match system.run() {
+        Ok(_) => println!("Completed"),
+        Err(e) => println!("An error occured: {:?}", e),
+    }
 
     match now.elapsed() {
         Ok(elapsed) => println!(
-            "Time taken: {}.{:06} seconds",
+            "Time taken: {}.{:06} seconds ({} msg/second)",
             elapsed.as_secs(),
-            elapsed.subsec_micros()
+            elapsed.subsec_micros(), (n_nodes * n_times * 1000000) as u128 / elapsed.as_micros()
         ),
         Err(e) => println!("An error occured: {:?}", e),
     }

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -33,12 +33,22 @@ impl Handler<Payload> for Node {
 
     fn handle(&mut self, msg: Payload, _: &mut Context<Self>) {
         if msg.0 >= self.limit {
-            println!("Actor {} reached limit of {} (payload was {})", self.id, self.limit, msg.0);
+            println!(
+                "Actor {} reached limit of {} (payload was {})",
+                self.id, self.limit, msg.0
+            );
             System::current().stop();
             return;
         }
-        if msg.0 % 498989 == 1 { // prime
-            println!("Actor {} received message {} of {} ({:.2}%)", self.id, msg.0, self.limit, 100.0 * msg.0 as f32 / self.limit as f32);
+        if msg.0 % 498989 == 1 {
+            // prime
+            println!(
+                "Actor {} received message {} of {} ({:.2}%)",
+                self.id,
+                msg.0,
+                self.limit,
+                100.0 * msg.0 as f32 / self.limit as f32
+            );
         }
         self.next
             .do_send(Payload(msg.0 + 1))
@@ -111,7 +121,10 @@ fn main() -> std::io::Result<()> {
         ),
         Err(e) => println!("An error occured: {:?}", e),
     }
-    println!("Sending start message and waiting for termination after {} messages...", limit);
+    println!(
+        "Sending start message and waiting for termination after {} messages...",
+        limit
+    );
     let now = SystemTime::now();
 
     let _req = node.send(Payload(1));
@@ -125,7 +138,8 @@ fn main() -> std::io::Result<()> {
         Ok(elapsed) => println!(
             "Time taken: {}.{:06} seconds ({} msg/second)",
             elapsed.as_secs(),
-            elapsed.subsec_micros(), (n_nodes * n_times * 1000000) as u128 / elapsed.as_micros()
+            elapsed.subsec_micros(),
+            (n_nodes * n_times * 1000000) as u128 / elapsed.as_micros()
         ),
         Err(e) => println!("An error occured: {:?}", e),
     }

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -40,8 +40,9 @@ impl Handler<Payload> for Node {
             System::current().stop();
             return;
         }
+        // Some prime in order for different actors to report progress.
+        // Large enough to print about once per second in debug mode.
         if msg.0 % 498989 == 1 {
-            // prime
             println!(
                 "Actor {} received message {} of {} ({:.2}%)",
                 self.id,

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -82,15 +82,15 @@ fn main() -> std::io::Result<()> {
         let first_addr = ctx.address();
         let mut prev_addr = Node {
             id: 1,
-            limit: limit,
+            limit,
             next: first_addr.recipient(),
         }
         .start();
 
-        for i in 2..n_nodes {
+        for id in 2..n_nodes {
             prev_addr = Node {
-                id: i,
-                limit: limit,
+                id,
+                limit,
                 next: prev_addr.recipient(),
             }
             .start();
@@ -98,7 +98,7 @@ fn main() -> std::io::Result<()> {
 
         Node {
             id: n_nodes,
-            limit: limit,
+            limit,
             next: prev_addr.recipient(),
         }
     });

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -19,6 +19,7 @@ impl Message for Payload {
 }
 
 struct Node {
+    id: usize,
     limit: usize,
     next: Recipient<Payload>,
 }
@@ -75,13 +76,15 @@ async fn main() {
     let node = Node::create(move |ctx| {
         let first_addr = ctx.address();
         let mut prev_addr = Node {
+            id: 1,
             limit: n_nodes * n_times,
             next: first_addr.recipient(),
         }
         .start();
 
-        for _ in 2..n_nodes {
+        for i in 2..n_nodes {
             prev_addr = Node {
+                id: i,
                 limit: n_nodes * n_times,
                 next: prev_addr.recipient(),
             }
@@ -89,6 +92,7 @@ async fn main() {
         }
 
         Node {
+            id: n_nodes,
             limit: n_nodes * n_times,
             next: prev_addr.recipient(),
         }

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -74,7 +74,7 @@ fn main() -> std::io::Result<()> {
         print_usage_and_exit()
     };
 
-    let now = SystemTime::now();
+    let setup = SystemTime::now();
 
     println!("Setting up nodes");
     let limit = n_nodes * n_times;
@@ -102,6 +102,17 @@ fn main() -> std::io::Result<()> {
             next: prev_addr.recipient(),
         }
     });
+
+    match setup.elapsed() {
+        Ok(elapsed) => println!(
+            "Time taken: {}.{:06} seconds",
+            elapsed.as_secs(),
+            elapsed.subsec_micros()
+        ),
+        Err(e) => println!("An error occured: {:?}", e),
+    }
+    println!("Sending start message and waiting for termination after {} messages...", limit);
+    let now = SystemTime::now();
 
     let _req = node.send(Payload(1));
     system.run();

--- a/examples/ring.rs
+++ b/examples/ring.rs
@@ -76,11 +76,12 @@ async fn main() {
     let now = SystemTime::now();
 
     println!("Setting up nodes");
+    let limit = n_nodes * n_times;
     let node = Node::create(move |ctx| {
         let first_addr = ctx.address();
         let mut prev_addr = Node {
             id: 1,
-            limit: n_nodes * n_times,
+            limit: limit,
             next: first_addr.recipient(),
         }
         .start();
@@ -88,7 +89,7 @@ async fn main() {
         for i in 2..n_nodes {
             prev_addr = Node {
                 id: i,
-                limit: n_nodes * n_times,
+                limit: limit,
                 next: prev_addr.recipient(),
             }
             .start();
@@ -96,7 +97,7 @@ async fn main() {
 
         Node {
             id: n_nodes,
-            limit: n_nodes * n_times,
+            limit: limit,
             next: prev_addr.recipient(),
         }
     });


### PR DESCRIPTION
This PR fixes the ring example, which terminates after just a few tens of messages is sent, instead of waiting for all messages to flow through the ring, which makes for a very misleading benchmark (which is why I noticed.)

Also adds some more informative output, such as messages sent per second.

I know very little of actix, as I started playing around with it today, and I expect someone who knows actix to be able to do better, but this is at least an improvement over the current state.