### PR TITLE
Lower constrain on MessageResponse for ResponseActFuture

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -155,11 +155,10 @@ where
     }
 }
 
-impl<A, M, I: 'static, E: 'static> MessageResponse<A, M>
-    for ResponseActFuture<A, Result<I, E>>
+impl<A, M, T: 'static> MessageResponse<A, M> for ResponseActFuture<A, T>
 where
     A: Actor,
-    M: Message<Result = Result<I, E>>,
+    M: Message<Result = T>,
     A::Context: AsyncContext<A>,
 {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>) {


### PR DESCRIPTION
Since Futures doesn't require a Ok and an Err type anymore, I see no reason for the `MessageResponse<A, M>` for a `ResponseActFuture<A, T>` to require that `T` is a `Result`.

The current code also doesn't add any constrains to the `I` and `E` used on the `Result<I, E>`, so using any static type `T` for the `ResponseActFuture` here does seam more appropriated since it's more generic.