### PR TITLE
Fix polling ResponseFuture returned by Handler (#315)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## [0.9.1] 2020-??-??
+
+### Fixed
+
+* Fix `MessageResponse` implementation  for `ResponseFuture` to always poll the spawned `Future`. (#317)
+
 ## [0.9.0] 2019-12-20
 
 ### Fixed

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -181,8 +181,9 @@ where
 {
     fn handle<R: ResponseChannel<M>>(self, _: &mut A::Context, tx: Option<R>) {
         actix_rt::spawn(async move {
+            let res = self.await;
             if let Some(tx) = tx {
-                tx.send(self.await)
+                tx.send(res)
             }
         });
     }


### PR DESCRIPTION
Fixes #315 

> The regression actually appeared here:  
> https://github.com/actix/actix/commit/aeb7bd15ea8793e5f00f17caefb01eb678136c2e#diff-057239071828d04f3e4c9ce9b814cdb0L179-L185  
> where
> ```rust
> actix_rt::spawn(self.then(move |res| {
>     if let Some(tx) = tx {
>         tx.send(res)
>     }
> ```
> was replaced with
> ```rust
> actix_rt::spawn(async move {
>     if let Some(tx) = tx {
>         tx.send(self.await)
>     }
> ```
> so the `Stream` is polled only if `tx` is provided.