### PR TITLE
Removed actix-http dependency and http feature

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,9 @@
 
 ## [NEXT]
 
-CHANGES
+### Changed
 
-* Breaking: removed actix feature `http`. Actix support for http was moved solely to actix-http and actix-web crates.
+* Feature `http` was removed. Actix support for http was moved solely to actix-http and actix-web crates.
 
 ## [0.9.1] 2020-??-??
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## [NEXT]
+
+CHANGES
+
+* Breaking: removed actix feature `http`. Actix support for http was moved solely to actix-http and actix-web crates.
+
 ## [0.9.1] 2020-??-??
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,13 @@ path = "src/lib.rs"
 members = ["examples/chat"]
 
 [features]
-default = ["resolver", "http"]
+default = ["resolver"]
 
 # dns resolver
 resolver = ["trust-dns-proto", "trust-dns-resolver"]
 
 # Adds assertion to prevent processing too many messages on event loop
 mailbox_assert = []
-
-# actix-http support
-http = ["actix-http"]
 
 [dependencies]
 actix-rt = "1.0.0"
@@ -50,9 +47,6 @@ smallvec = "1.0"
 parking_lot = "0.10"
 tokio = { version = "0.2.6", default-features = false, features=["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "sync"] }
 tokio-util   = { version = "0.2", features = ["full"] }
-
-# actix-http support
-actix-http = { version = "1.0.1", optional = true }
 
 # dns resolver
 trust-dns-proto = { version = "=0.18.0-alpha.2", optional = true, default-features = false }

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -146,10 +146,6 @@ pub enum ResolverError {
     IoError(io::Error),
 }
 
-/// `InternalServerError` for `actix::MailboxError`
-#[cfg(feature = "http")]
-impl actix_http::ResponseError for ResolverError {}
-
 pub struct Resolver {
     resolver: Option<AsyncResolver>,
     cfg: Option<(ResolverConfig, ResolverOpts)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,3 @@ where
 {
     actix_rt::spawn(f);
 }
-
-/// `InternalServerError` for `actix::MailboxError`
-#[cfg(feature = "http")]
-impl actix_http::ResponseError for MailboxError {}


### PR DESCRIPTION
This fix should resolve #321 to enable moving actix-http specific trait implementations for actors to actix-http crate:

 - https://github.com/actix/actix/blob/ba9f0a374462b80374ab9ecf5956c4a1265e7a87/src/lib.rs#L208
 - https://github.com/actix/actix/blob/ba9f0a374462b80374ab9ecf5956c4a1265e7a87/src/actors/resolver.rs#L151

After this change applied and actix published to crates, we can make actix a dependency for actix-http and implement mentioned traits in the actix-http crate.