### PR TITLE
Improves documentation on how to asynchronously handle messages

### DIFF
--- a/src/fut/mod.rs
+++ b/src/fut/mod.rs
@@ -57,39 +57,39 @@ use std::pin::Pin;
 /// // This is the needed result for the DeferredWork message
 /// // It's a result that combine both Response and Error from the future response.
 /// type DeferredWorkResult = Result<OriginalActorResponse, MessageError>;
-///
+/// #
 /// # struct ActorState {}
-///
+/// #
 /// # impl ActorState {
 /// #    fn update_from(&mut self, _result: ()) {}
 /// # }
-///
+/// #
 /// # struct OtherActor {}
-///
+/// #
 /// # impl Actor for OtherActor {
 /// #    type Context = Context<Self>;
 /// # }
-///
+/// #
 /// # impl Handler<OtherMessage> for OtherActor {
 /// #    type Result = ();
 /// #
 /// #    fn handle(&mut self, _msg: OtherMessage, _ctx: &mut Context<Self>) -> Self::Result {
 /// #    }
 /// # }
-///
+/// #
 /// # struct OriginalActor{
 /// #     other_actor: Addr<OtherActor>,
 /// #     inner_state: ActorState
 /// # }
-///
+/// #
 /// # impl Actor for OriginalActor{
 /// #     type Context = Context<Self>;
 /// # }
-///
+/// #
 /// # #[derive(Message)]
 /// # #[rtype(result = "Result<(), MessageError>")]
 /// # struct DeferredWork{}
-///
+/// #
 /// # #[derive(Message)]
 /// # #[rtype(result = "()")]
 /// # struct OtherMessage{}

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -24,6 +24,9 @@ where
     M: Message,
 {
     /// The type of value that this handler will return.
+    ///
+    /// Check the [MessageResponse] trait for some details
+    /// on how a message can be responded to.
     type Result: MessageResponse<Self, M>;
 
     /// This method is called for every message received by this actor.
@@ -54,12 +57,113 @@ where
 }
 
 /// A helper type that implements the `MessageResponse` trait.
+///
+/// # Examples
+/// ```rust, no_run
+/// use actix::prelude::*;
+///
+/// #[derive(Message)]
+/// #[rtype(result = "Response")]
+/// struct Msg;
+///
+/// struct Response;
+///
+/// struct MyActor;
+///
+/// impl Actor for MyActor {
+///     type Context = Context<Self>;
+/// }
+///
+/// impl Handler<Msg> for MyActor {
+///     type Result = MessageResult<Msg>;
+///
+///     fn handle(&mut self, _: Msg, _: &mut Context<Self>) -> Self::Result {
+///         MessageResult(Response {})
+///     }
+/// }
+/// ```
 pub struct MessageResult<M: Message>(pub M::Result);
 
 /// A specialized actor future for asynchronous message handling.
+///
+/// Intended be used from when the future returned will,
+/// at some point, need to access Actor's internal state or context
+/// in order to finish.
+/// Check [ActorFuture] for available methods for accessing Actor's
+/// internal state.
+///
+/// ## Note
+/// It's important to keep in mind that the provided `AsyncContext`,
+/// [Context], does not enforce the poll of any [ActorFuture] to be
+/// exclusive. Therefore, if other instances of [ActorFuture] are spawned
+/// into this Context **their execution won't necessarily be atomic**.
+///
+/// # Examples
+/// ```rust, no_run
+/// use actix::prelude::*;
+///
+/// #[derive(Message)]
+/// #[rtype(result = "Result<usize, ()>")]
+/// struct Msg;
+///
+/// struct MyActor;
+///
+/// impl Actor for MyActor {
+///     type Context = Context<Self>;
+/// }
+///
+/// impl Handler<Msg> for MyActor {
+///     type Result = ResponseActFuture<Self, Result<usize, ()>>;
+///
+///     fn handle(&mut self, _: Msg, _: &mut Context<Self>) -> Self::Result {
+///         Box::new(
+///             async {
+///                 // Some async computation
+///                 42
+///             }
+///             .into_actor(self) // converts future to ActorFuture
+///             .map(|res, _act, _ctx| {
+///                 // Do some computation with actor's state or context
+///                 Ok(res)
+///             }),
+///         )
+///     }
+/// }
+/// ```
 pub type ResponseActFuture<A, I> = Box<dyn ActorFuture<Output = I, Actor = A>>;
 
 /// A specialized future for asynchronous message handling.
+///
+/// Intended be used for when the future returned doesn't
+/// need to access Actor's internal state or context to progress, either
+/// because it's completely agnostic to it, or because the required data has
+/// already been moved inside the future and it won't need Actor state to continue.
+///
+/// # Examples
+/// ```rust, no_run
+/// use actix::prelude::*;
+///
+/// #[derive(Message)]
+/// #[rtype(result = "Result<(), ()>")]
+/// struct Msg;
+///
+/// struct MyActor;
+///
+/// impl Actor for MyActor {
+///     type Context = Context<Self>;
+/// }
+///
+/// impl Handler<Msg> for MyActor {
+///     type Result = ResponseFuture<Result<(), ()>>;
+///
+///     fn handle(&mut self, _: Msg, _: &mut Context<Self>) -> Self::Result {
+///         Box::pin(async move {
+///             // Some async computation
+///             Ok(())
+///         })
+///     }
+/// }
+/// ```
 pub type ResponseFuture<I> = Pin<Box<dyn Future<Output = I>>>;
 
 /// A trait that defines a message response channel.
@@ -70,6 +174,21 @@ pub trait ResponseChannel<M: Message>: 'static {
 }
 
 /// A trait which defines message responses.
+///
+/// We offer implementation for some common language types, if you need
+/// to respond with a new type you can use [MessageResult].
+///
+/// If `Actor::Context` implements [AsyncContext] it's possible to handle
+/// the message asynchronously.
+/// For asynchronous message handling we offer two possible response types
+/// [ResponseFuture] and [ResponseActFuture].
+/// - [ResponseFuture] should be used for when the future returned doesn't
+///   need to access Actor's internal state or context to progress, either
+///   because it's completely agnostic to it or because the required data has
+///   already been moved to it and it won't need Actor state to continue.
+/// - [ResponseActFuture] should be used from when the future returned
+///   will, at some point, need to access Actor's internal state or context
+///   in order to finish.
 pub trait MessageResponse<A: Actor, M: Message> {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>);
 }


### PR DESCRIPTION
Recently there has been quite a feel people on the repo and on gitter asking and discussing about how to asynchronously handle messages using Actix. This PR mains at improving the documentation of the offered types and implementations and tries to guide uses to the right types upon navigating the docs. I've added some examples to the types in order illustrate a littler better how to use the API as well.

I encourage users to point out any misleading, confusing or incomplete points in the doc related to asynchronous message handling so we can all make the library a littler easier to use.