### PR TITLE
Enable the Tokio feature "io-util" 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ lazy_static = "1.4"
 bitflags = "1.2"
 smallvec = "1.0"
 parking_lot = "0.10"
-tokio = { version = "0.2.6", default-features = false, features=["rt-core", "rt-util", "io-driver", "tcp", "uds", "udp", "time", "signal", "sync"] }
+tokio = { version = "0.2.6", default-features = false, features=["rt-core", "rt-util", "io-driver", "io-util", "tcp", "uds", "udp", "time", "signal", "sync"] }
 tokio-util   = { version = "0.2", features = ["full"] }
 
 # actix-http support


### PR DESCRIPTION
Without the `io-util` flag, compiling actix with the default features disabled results in the following error:

```
error[E0432]: unresolved import `tokio::io::AsyncWriteExt`
  --> src\io.rs:12:29
   |
12 | use tokio::io::{AsyncWrite, AsyncWriteExt};
   |                             ^^^^^^^^^^^^^
   |                             |
   |                             no `AsyncWriteExt` in `io`
   |                             help: a similar name exists in the module: `AsyncWrite`

error[E0599]: no method named `write` found for type `std::cell::RefMut<'_, T>` in the current scope
   --> src\io.rs:418:34
    |
418 |             let _ = async_writer.write(&inner.buffer);
    |                                  ^^^^^ method not found in `std::cell::RefMut<'_, T>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `write`, perhaps you need to implement one of them:
            candidate #1: `std::io::Write`
            candidate #2: `std::hash::Hasher`
            candidate #3: `futures_util::io::AsyncWriteExt`

error[E0599]: no method named `flush` found for type `std::cell::RefMut<'_, T>` in the current scope
   --> src\io.rs:419:34
    |
419 |             let _ = async_writer.flush();
    |                                  ^^^^^ method not found in `std::cell::RefMut<'_, T>`
    |
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `flush`, perhaps you need to implement one of them:
            candidate #1: `std::io::Write`
            candidate #2: `futures_util::sink::SinkExt`
            candidate #3: `futures_util::io::AsyncWriteExt`
            candidate #4: `log::Log`

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `actix`.

To learn more, run the command again with --verbose.
```