### PR TITLE
Fix typo for examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 The following examples complement the documentation and can help you understand how to use Actix:
 
 1. [Ping](https://github.com/actix/actix/blob/master/examples/ping.rs) - Basic example showing 2 actors playing ping/pong.
-2. [Fibonnaci](https://github.com/actix/actix/blob/master/examples/fibonacci.rs) - Demonstrates how to integrate a synchronous actor on a threadpool for cpu bound tasks.
+2. [Fibonacci](https://github.com/actix/actix/blob/master/examples/fibonacci.rs) - Demonstrates how to integrate a synchronous actor on a threadpool for cpu bound tasks.
 3. [Ring](https://github.com/actix/actix/blob/master/examples/ring.rs) - Ring benchmark inspired by Programming Erlang: Software for a Concurrent World. Send a M messages round a ring of N actors and benchmark.
 4. [Chat](https://github.com/actix/actix/tree/master/examples/chat/src) - More realistic application example of a chat server/client
 


### PR DESCRIPTION
Fix examples/README.md.

Fibonnaci => Fibonacci