### PR TITLE
PoC of AsyncHandler trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,9 @@ mailbox_assert = []
 # actix-http support
 http = ["actix-http"]
 
+# mocker
+mocker = []
+
 [dependencies]
 actix-rt = "1.0.0"
 actix_derive = "0.5"

--- a/src/actors/mod.rs
+++ b/src/actors/mod.rs
@@ -1,5 +1,6 @@
 //! Helper actors
 
+#[cfg(feature = "mocker")]
 pub mod mocker;
 
 #[cfg(feature = "resolver")]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -24,8 +24,6 @@ impl<T> TempRef<T> {
             let x = self.inner;
             &*x
         }
-
-        //        todo!()
     }
     pub fn as_mut(&mut self) -> &mut T {
         unsafe {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -43,19 +43,6 @@ where
 {
     type Result: Future<Output = M::Result> + Sized + 'static;
 
-    //    fn handle(&mut self, msg: (), ctx: &mut Context<MyActor>) {
-    //        use std::sync::Weak;
-    //
-    //        let this = self as *mut Self;
-    //
-    //        let handle = AsyncActorHandle {
-    //            inner: this
-    //        };
-    //
-    //
-    //        Self::async_handle(handle, ());
-    //    }
-
     fn handle(
         actor: TempRef<Self>,
         msg: M,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -377,7 +377,7 @@ where
     }
 }
 
-pub struct AsyncResponse<M: AsyncMessage>(pub M::Result);
+pub struct AsyncResponse<M: AsyncMessage>(M::Result);
 
 impl<A, M> MessageResponse<A, M> for ResponseFuture<AsyncResponse<M>>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr};
 pub use crate::context::Context;
 pub use crate::fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};
 pub use crate::handler::{
-    ActorResponse, Handler, Message, MessageResult, Response, ResponseActFuture,
-    ResponseFuture,
+    ActorResponse, AsyncHandler, AsyncMessage, Handler, Message, MessageResult,
+    Response, ResponseActFuture, ResponseFuture, TempRef,
 };
 pub use crate::registry::{ArbiterService, Registry, SystemRegistry, SystemService};
 pub use crate::stream::StreamHandler;

--- a/tests/test_async_actor.rs
+++ b/tests/test_async_actor.rs
@@ -4,8 +4,8 @@ use futures::{future::ready, StreamExt};
 
 use actix::prelude::*;
 use actix::{AsyncHandler, AsyncMessage, TempRef};
-use tokio::time::delay_for;
 use std::time::{Duration, Instant};
+use tokio::time::delay_for;
 
 #[derive(Debug, Clone, Copy)]
 struct Num(usize);

--- a/tests/test_async_actor.rs
+++ b/tests/test_async_actor.rs
@@ -1,0 +1,69 @@
+use std::pin::Pin;
+use std::sync;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use futures::channel::oneshot::{self, Canceled};
+use futures::FutureExt;
+use futures::StreamExt;
+use tokio::time::{delay_for, Duration, Instant};
+
+use actix::fut::wrap_future;
+use actix::prelude::dev::MessageResponse;
+use actix::prelude::*;
+use actix::{AsyncHandler, AsyncMessage, TempRef};
+
+type OriginalActorResponse = ();
+type MessageError = ();
+type DeferredWorkResult = Result<OriginalActorResponse, MessageError>;
+
+#[derive(Debug, Clone, Copy)]
+struct Num(usize);
+
+impl Message for Num {
+    type Result = usize;
+}
+
+impl AsyncMessage for Num {}
+
+struct MyActor {
+    count: usize,
+}
+
+impl Actor for MyActor {
+    type Context = actix::Context<Self>;
+}
+
+impl AsyncHandler<Num> for MyActor {
+    type Result = Pin<Box<dyn Future<Output = <Num as Message>::Result>>>;
+
+    fn handle(mut this: TempRef<Self>, msg: Num, _ctx: TempRef<Self::Context>) -> Self::Result {
+        let res = tokio::task::spawn(async move {
+            this.as_mut().count += msg.0;
+            this.as_ref().count
+        });
+
+        Box::pin(async move { res.await.unwrap() })
+    }
+}
+
+#[actix_rt::test]
+async fn test_async_actor() {
+    let items = vec![Num(1), Num(1), Num(2), Num(3), Num(5), Num(8), Num(13)];
+
+    let addr = MyActor { count: 0 }.start();
+
+    use futures::{future::ready, join, FutureExt, StreamExt};
+
+    let fut = futures::stream::iter(items.clone())
+        .map(move |i| addr.send(i))
+        .buffer_unordered(7)
+        .fold(vec![], |mut acc, res| {
+            acc.push(res.unwrap());
+            ready(acc)
+        });
+
+    let result = fut.await;
+
+    assert_eq!(result, vec![1, 2, 4, 7, 12, 20, 33]);
+}


### PR DESCRIPTION
Related to #308 

We discused this problem with @Jonathas-Conceicao in Gitter and I came up with an idea what I would like to have to work easier with async code in actors.

I wanted to tackle this problem: When actor needs to do some async IO, it becomes difficult to manage the state in all the different handlers and code becomes much more complex than needed.

Same result can be achieved with `wrap_future()` and `ctx.wait()` but then the code becomes rather unreadable if there are several async/await blocks involved. This way it's way more straight-forward.

This PR introduces a new trait: `AsyncHandler` with blanket implementation of `Handler` trait.

Idea is that result of `AsyncHandler::handle()` is always a future and actor system would guarantie that while the future is pending, actor wont receive another message, so then actor's state can be safely mutated in the mean time.

Disclaimer: It's Proof-of-concept and literraly my first unsafe code. 😄 

**Note:** Build fails because it runs with all the features enabled and `AsyncHandler` is currently conflicting with `Mocker` giving error:
```
error[E0119]: conflicting implementations of trait `handler::Handler<_>` for type `actors::mocker::Mocker<_>`
```