### PR TITLE
Replace some uses of `Pin::get_unchecked_mut` with `pin_project`

### DIFF
--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -340,7 +340,6 @@ where
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // let this = unsafe { self.get_unchecked_mut() };
         let this = self.get_mut();
 
         if !this.ctx.parts().flags.contains(ContextFlags::STARTED) {

--- a/src/fut/result.rs
+++ b/src/fut/result.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task;
 use std::task::Poll;
+use pin_project::pin_project;
 
 use crate::actor::Actor;
 use crate::fut::ActorFuture;
@@ -10,6 +11,7 @@ use crate::fut::ActorFuture;
 /// A future representing a value that is immediately ready.
 ///
 /// Created by the `result` function.
+#[pin_project]
 #[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 // TODO: rename this to `Result` on the next major version
@@ -102,7 +104,7 @@ where
         _: &mut task::Context<'_>,
     ) -> Poll<Self::Output> {
         Poll::Ready(
-            unsafe { self.get_unchecked_mut() }
+            self.project()
                 .inner
                 .take()
                 .expect("cannot poll Result twice"),


### PR DESCRIPTION
This removes several uses of `unsafe`, while making the code more readable.

There are still some uses of `Pin::get_unchecked_mut` remaining. There's no straightforward way to replace them with `#[pin_project]`. There are two main reasons for this:

1. `#[pin_project]` lacks the ability to project through an `Option`. I *think* that it should be possible to do this is a sound manner, but I'm not 100% certain. 
2. The code structure doesn't make it clear that a pinned type is never moved. For example, `StreamFold::poll` calls `mem::replace` on a `State` value, but also pins values inside `Stream::Ready` and `Stream::Processing`. It's not obvious to me whether or not the current code is sound.