### PR TITLE
Fix link to the chat example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ The following examples complement the documentation and can help you understand 
 1. [Ping](https://github.com/actix/actix/blob/master/examples/ping.rs) - Basic example showing 2 actors playing ping/pong.
 2. [Fibonacci](https://github.com/actix/actix/blob/master/examples/fibonacci.rs) - Demonstrates how to integrate a synchronous actor on a threadpool for cpu bound tasks.
 3. [Ring](https://github.com/actix/actix/blob/master/examples/ring.rs) - Ring benchmark inspired by Programming Erlang: Software for a Concurrent World. Send a M messages round a ring of N actors and benchmark.
-4. [Chat](https://github.com/actix/actix/tree/master/examples/chat/src) - More realistic application example of a chat server/client
+4. [Chat](https://github.com/actix/actix/tree/master/examples/chat) - More realistic application example of a chat server/client
 
 ## External Examples
 


### PR DESCRIPTION
I was on the page https://github.com/actix/actix/tree/master/examples/chat/src wondering what dependencies I should add to 'Cargo.toml`, then I realized that https://github.com/actix/actix/tree/master/examples/chat has everything I need. 

This PR updates the link so it's less confusing.