### PR TITLE
Allows a more permissive handing of `ResponseFuture`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
 
 * Allow return of any `T: 'static` on `ResponseFuture`. (#343)
 
+* Allow return of any `T: 'static` on `ResponseActFuture`. (#310)
+
 ## [0.9.0] 2019-12-20
 
 ### Fixed

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@
 
 * Fix `MessageResponse` implementation  for `ResponseFuture` to always poll the spawned `Future`. (#317)
 
+### Added
+
+* Allow return of any `T: 'static` on `ResponseFuture`. (#343)
+
 ## [0.9.0] 2019-12-20
 
 ### Fixed

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -290,26 +290,29 @@ where
     }
 }
 
-/// MessageResponse trait impl to enbale the use of any I: 'static with Actor Handlers
-/// Usage with Result<I,E>:
+/// MessageResponse trait impl to enbale the use of any `I: 'static` with asynchronous
+/// message handling
+///
+/// # Examples
+/// Usage with `Result<I,E>`:
 /// ```
 /// # pub struct MyActorAsync {}
 /// # impl Actor for MyActorAsync { type Context = actix::Context<Self>; }
 /// # use actix::prelude::*;
 /// # use core::pin::Pin;
-/// 
+/// #
 /// pub struct MyQuestion{}
 /// impl Message for MyQuestion {
 ///     type Result = Result<u8,u8>;
 /// }
 /// impl Handler<MyQuestion> for MyActorAsync {
-///     type Result = Pin<Box<dyn std::future::Future<Output = Result<u8,u8> >>>;
+///     type Result = ResponseFuture<Result<u8,u8>>;
 ///     fn handle(&mut self, question: MyQuestion, _ctx: &mut Context<Self>) -> Self::Result {
 ///         Box::pin(async {Ok(5)})
 ///     }
 /// }
 /// ```
-/// Usage with Option<I>:
+/// Usage with `Option<I>`:
 /// ```
 /// # pub struct MyActorAsync {}
 /// # impl Actor for MyActorAsync { type Context = actix::Context<Self>; }
@@ -320,13 +323,13 @@ where
 ///     type Result = Option<u8>;
 /// }
 /// impl Handler<MyQuestion> for MyActorAsync {
-///     type Result = Pin<Box<dyn std::future::Future<Output = Option<u8>>>>;
+///     type Result = ResponseFuture<Option<u8>>;
 ///     fn handle(&mut self, question: MyQuestion, _ctx: &mut Context<Self>) -> Self::Result {
 ///         Box::pin(async {Some(5)})
 ///     }
 /// }
 /// ```
-/// Usage with any I: 'static
+/// Usage with any `I: 'static`:
 /// ```
 /// # pub struct MyActorAsync {}
 /// # impl Actor for MyActorAsync { type Context = actix::Context<Self>; }
@@ -337,7 +340,7 @@ where
 ///     type Result = u8;
 /// }
 /// impl Handler<MyQuestion> for MyActorAsync {
-///     type Result = Pin<Box<dyn std::future::Future<Output = u8>>>;
+///     type Result = ResponseFuture<u8>;
 ///     fn handle(&mut self, question: MyQuestion, _ctx: &mut Context<Self>) -> Self::Result {
 ///         Box::pin(async {5})
 ///     }


### PR DESCRIPTION
This finishes the work started by @mocsy on #313.

Closes #313