### PR TITLE
Make more uses of Pin safe

### DIFF
--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -61,7 +61,7 @@ where
         cx: &mut task::Context<'_>,
     ) -> Poll<Result<M::Result, MailboxError>> {
         if let Some(ref mut timeout) = self.timeout {
-            match unsafe { Pin::new_unchecked(timeout) }.poll(cx) {
+            match Pin::new(timeout).poll(cx) {
                 Poll::Ready(()) => Poll::Ready(Err(MailboxError::Timeout)),
                 Poll::Pending => Poll::Pending,
             }

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -6,6 +6,8 @@ use std::time::Duration;
 
 use futures::channel::oneshot;
 
+use pin_project::pin_project;
+
 use crate::clock::Delay;
 use crate::handler::{Handler, Message};
 
@@ -15,6 +17,7 @@ use super::{MailboxError, SendError, ToEnvelope};
 /// A `Future` which represents an asynchronous message sending
 /// process.
 #[must_use = "You have to wait on request otherwise the Message wont be delivered"]
+#[pin_project]
 pub struct Request<A, M>
 where
     A: Handler<M>,
@@ -80,14 +83,14 @@ where
 {
     type Output = Result<M::Result, MailboxError>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        let mut this = unsafe { self.get_unchecked_mut() };
+    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        let this = self.as_mut().project();
 
         if let Some((sender, msg)) = this.info.take() {
             match sender.send(msg) {
-                Ok(rx) => this.rx = Some(rx),
+                Ok(rx) => *this.rx = Some(rx),
                 Err(SendError::Full(msg)) => {
-                    this.info = Some((sender, msg));
+                    *this.info = Some((sender, msg));
                     return Poll::Pending;
                 }
                 Err(SendError::Closed(_)) => {
@@ -97,11 +100,11 @@ where
         }
 
         if this.rx.is_some() {
-            match unsafe { Pin::new_unchecked(&mut this.rx.as_mut().unwrap()) }.poll(cx)
+            match Pin::new(&mut this.rx.as_mut().unwrap()).poll(cx)
             {
                 Poll::Ready(Ok(i)) => Poll::Ready(Ok(i)),
                 Poll::Ready(Err(_)) => Poll::Ready(Err(MailboxError::Closed)),
-                Poll::Pending => this.poll_timeout(cx),
+                Poll::Pending => self.poll_timeout(cx),
             }
         } else {
             Poll::Ready(Err(MailboxError::Closed))

--- a/src/fut/stream_fold.rs
+++ b/src/fut/stream_fold.rs
@@ -87,7 +87,7 @@ where
                     }
                 }
                 State::Processing(mut fut) => {
-                    match unsafe { Pin::new_unchecked(&mut fut) }.poll(act, ctx, task) {
+                    match Pin::new(&mut fut).poll(act, ctx, task) {
                         Poll::Ready(state) => this.state = State::Ready(state),
                         Poll::Pending => {
                             this.state = State::Processing(fut);


### PR DESCRIPTION
After this PR, the only remaining use of `unsafe` with `Pin` comes from `impl ActorFuture for Box`.