### PR TITLE
Only implement `ActorFuture` for Box where `ActorFuture` is `Unpin`

### DIFF
--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -25,7 +25,7 @@ bitflags! {
     }
 }
 
-type Item<A> = (SpawnHandle, Box<dyn ActorFuture<Output = (), Actor = A>>);
+type Item<A> = (SpawnHandle, Pin<Box<dyn ActorFuture<Output = (), Actor = A>>>);
 
 pub trait AsyncContextParts<A>: ActorContext + AsyncContext<A>
 where
@@ -134,7 +134,7 @@ where
         let handle = self.handles[0].next();
         self.handles[0] = handle;
         let fut: Box<dyn ActorFuture<Output = (), Actor = A>> = Box::new(fut);
-        self.items.push((handle, fut));
+        self.items.push((handle, Pin::from(fut)));
         handle
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -281,7 +281,7 @@ where
     A::Context: AsyncContext<A>,
 {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>) {
-        ctx.spawn(self.then(move |res, this, _| {
+        ctx.spawn(Box::new(Pin::from(self)).then(move |res, this, _| {
             if let Some(tx) = tx {
                 tx.send(res);
             }
@@ -478,7 +478,7 @@ where
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>) {
         match self.item {
             ActorResponseTypeItem::Fut(fut) => {
-                let fut = fut.then(move |res, this, _| {
+                let fut = Box::new(Pin::from(fut)).then(move |res, this, _| {
                     if let Some(tx) = tx {
                         tx.send(res)
                     }


### PR DESCRIPTION
This is a breaking change.

The previous impl was unsound: it allowed going from a `Pin<&mut Box<F>>`
to a `Pin<&mut F>`. However, the fact that `Box<T>` is `Unpin` for all
`T` means that it's possible to go from a `Pin<&mut Box<F>>` to a
`&mut Box<F>`. This allows a user to construct a `Pin<&mut F>`, and them
move the underlying `F` by obtaining a `&mut Box<F>` and calling
`mem::swap`.

The new impl adds an `Unpin` bound to `F`, bringing it in line with the
standard library's impl of `Future` for `Box<F>`.4

We can make `Box<F> where F: ActorFuture` easier to work with by
'porting' a `Future`-related impl from the standard library. By making
`Pin<Box<F>>` implement `ActorFuture` (e.g. you can call `poll` on a
`Pin<&mut Pin<Box<F>>>`), it's possible to avoid introducing extra
`Box`s in many cases. If you have ownership of a `Box<F>`, you can use
`Box::pin` to get a `Pin<Box<F>>`, which implements `ActorFuture`
*regardless of whether or not `F` is `Unpin`.

In a few cases, it was necessary to introduce an extra `Box`.
The alternatives would be to add an `Unpin` bound to a public type (e.g.
`ResponseActFuture`, or change the signature of a function to take a
`Pin<&mut Self>`). Adding a `Box` seemed like the simplest change - the
relevant code was already using a `Box`, so this didn't introduce heap
allocations into code that previously required no allocations.