### PR TITLE
Upgrade Resolver Actor to use newest trust_dns versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,12 @@
 
 * Allow return of any `T: 'static` on `ResponseActFuture`. (#310)
 
+### Changed
+
+* Upgrade `trust-dns-proto` to 0.19
+
+* Upgrade `trust-dns-resolver` to 0.19
+
 ## [0.9.0] 2019-12-20
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ tokio-util   = { version = "0.2", features = ["full"] }
 actix-http = { version = "1.0.1", optional = true }
 
 # dns resolver
-trust-dns-proto = { version = "=0.18.0-alpha.2", optional = true, default-features = false }
-trust-dns-resolver = { version = "=0.18.0-alpha.2", optional = true, default-features = false }
+trust-dns-proto = { version = "0.19", optional = true, default-features = false, features = ["tokio-runtime"] }
+trust-dns-resolver = { version = "0.19", optional = true, default-features = false, features = ["tokio-runtime", "system-config"] }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -3,31 +3,27 @@
 //! ## Example
 //!
 //! ```rust
-//! #![recursion_limit="128"]
-//! use futures::{future, FutureExt};
-//! use actix::prelude::*;
 //! use actix::actors::resolver;
+//! use actix::prelude::*;
 //!
 //! #[actix_rt::main]
 //! async fn main() {
-//!         actix_rt::spawn(async {
-//!             let resolver = resolver::Resolver::from_registry();
+//!     Arbiter::spawn(async {
+//!         let resolver = resolver::Resolver::from_registry();
+//!         let addrs = resolver
+//!             .send(resolver::Resolve::host("localhost"))
+//!             .await
+//!             .unwrap();
 //!
-//!             let addrs = resolver.send(
-//!                  resolver::Connect::host("localhost")).await;
+//!         println!("RESULT: {:?}", addrs);
+//!     });
 //!
-//!             println!("RESULT: {:?}", addrs);
-//!             System::current().stop();
-//!        });
-//!
-//!         actix_rt::spawn(async {
-//!             let resolver = resolver::Resolver::from_registry();
-//!
-//!             let stream = resolver.send(
-//!                  resolver::Connect::host_and_port("localhost", 5000)).await;
-//!
-//!             println!("RESULT: {:?}", stream);
-//!        });
+//!     let resolver = resolver::Resolver::from_registry();
+//!     let addrs = resolver
+//!         .send(resolver::Connect::host_and_port("localhost", 5000))
+//!         .await
+//!         .unwrap();
+//!     println!("RESULT: {:?}", addrs);
 //! }
 //! ```
 use std::collections::VecDeque;

--- a/tests/test_actors.rs
+++ b/tests/test_actors.rs
@@ -5,14 +5,15 @@ use actix::prelude::*;
 async fn test_resolver() {
     Arbiter::spawn(async {
         let resolver = resolver::Resolver::from_registry();
-        let _ = resolver.send(resolver::Resolve::host("localhost")).await;
-        System::current().stop();
+        let _ = resolver
+            .send(resolver::Resolve::host("localhost"))
+            .await
+            .unwrap();
     });
 
-    Arbiter::spawn(async {
-        let resolver = resolver::Resolver::from_registry();
-        let _ = resolver
-            .send(resolver::Connect::host("localhost:5000"))
-            .await;
-    });
+    let resolver = resolver::Resolver::from_registry();
+    let _ = resolver
+        .send(resolver::Connect::host("localhost:5000"))
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
This also updates and fixes the `test_resolver` integration test and the example on `actors::resolver`, both which would finishing without any execution.

Closes #345