### PR TITLE
Enforce Pin on stored ActorFuture

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## [TBD] TBD
+
+## Changed
+
+* Require `Pin` for `ResponseActFuture`. [#355]
+
 ## [0.10.0-alpha.1] 2020-02-25
 
 ### Fixed

--- a/src/actors/resolver.rs
+++ b/src/actors/resolver.rs
@@ -223,9 +223,9 @@ impl Handler<Resolve> for Resolver {
 
     fn handle(&mut self, msg: Resolve, _: &mut Self::Context) -> Self::Result {
         if let Some(ref err) = self.err {
-            Box::new(ResolveFut::err(err.clone()))
+            Box::pin(ResolveFut::err(err.clone()))
         } else {
-            Box::new(ResolveFut::new(
+            Box::pin(ResolveFut::new(
                 msg.name,
                 msg.port.unwrap_or(0),
                 self.resolver.as_ref().unwrap(),
@@ -239,7 +239,7 @@ impl Handler<Connect> for Resolver {
 
     fn handle(&mut self, msg: Connect, _: &mut Self::Context) -> Self::Result {
         let timeout = msg.timeout;
-        Box::new(
+        Box::pin(
             ResolveFut::new(
                 msg.name,
                 msg.port.unwrap_or(0),
@@ -259,7 +259,7 @@ impl Handler<ConnectAddr> for Resolver {
     fn handle(&mut self, msg: ConnectAddr, _: &mut Self::Context) -> Self::Result {
         let mut v = VecDeque::new();
         v.push_back(msg.0);
-        Box::new(TcpConnector::new(v))
+        Box::pin(TcpConnector::new(v))
     }
 }
 

--- a/src/fut/mod.rs
+++ b/src/fut/mod.rs
@@ -122,7 +122,7 @@ use std::pin::Pin;
 ///         });
 ///
 ///         // return the wrapped future
-///         Box::new(update_self)
+///         Box::pin(update_self)
 ///     }
 /// }
 ///

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -116,7 +116,7 @@ pub struct MessageResult<M: Message>(pub M::Result);
 ///     type Result = ResponseActFuture<Self, Result<usize, ()>>;
 ///
 ///     fn handle(&mut self, _: Msg, _: &mut Context<Self>) -> Self::Result {
-///         Box::new(
+///         Box::pin(
 ///             async {
 ///                 // Some async computation
 ///                 42
@@ -130,7 +130,7 @@ pub struct MessageResult<M: Message>(pub M::Result);
 ///     }
 /// }
 /// ```
-pub type ResponseActFuture<A, I> = Box<dyn ActorFuture<Output = I, Actor = A>>;
+pub type ResponseActFuture<A, I> = Pin<Box<dyn ActorFuture<Output = I, Actor = A>>>;
 
 /// A specialized future for asynchronous message handling.
 ///
@@ -281,7 +281,7 @@ where
     A::Context: AsyncContext<A>,
 {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>) {
-        ctx.spawn(Box::new(Pin::from(self)).then(move |res, this, _| {
+        ctx.spawn(self.then(move |res, this, _| {
             if let Some(tx) = tx {
                 tx.send(res);
             }


### PR DESCRIPTION
The main change here is that `ResponseActFuture<A, I>` is now defined as `Pin<Box<dyn ActorFuture<Output = I, Actor = A>>>` instead of the old `Box<dyn ActorFuture<Output = I, Actor = A>>`, which is a public API change.

As #348 got merged boxing a `ActorFuture` is not enough to keep access to trait's methods, the user should also `Pin` it. As this was a breaking change, I believe that changing the type of `ResponseActFuture` should make it more clear that responses using it should be `Pin` and therefore make migrations of old code easier. This also changes some internal codes to `Pin` their boxed `ActorFuture` and it does make code a little clear.