### PR TITLE
Fix test_restart_sync_actor occasional fail

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,6 @@ jobs:
         with:
           command: test
           args: --all --all-features --no-fail-fast -- --nocapture
-                --skip=test_restart_sync_actor
 
       - name: Generate coverage file
         if: matrix.version == 'stable' && github.ref == 'refs/heads/master'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -60,7 +60,6 @@ jobs:
         with:
           command: test
           args: --all --all-features --no-fail-fast -- --nocapture
-                --skip=test_restart_sync_actor
                 --skip=test_start_actor_message
 
       - name: Clear the cargo caches

--- a/tests/test_actor.rs
+++ b/tests/test_actor.rs
@@ -73,6 +73,9 @@ impl Actor for MySyncActor {
     }
     fn stopped(&mut self, _: &mut Self::Context) {
         self.stopped.fetch_add(1, Ordering::Relaxed);
+        if self.stopped.load(Ordering::Relaxed) >= 2 {
+            System::current().stop();
+        }
     }
 }
 
@@ -112,8 +115,6 @@ fn test_restart_sync_actor() {
 
         actix_rt::spawn(async move {
             let _ = addr.send(Num(4)).await;
-            delay_for(Duration::new(0, 1_000_000)).await;
-            System::current().stop();
         });
     })
     .unwrap();


### PR DESCRIPTION
Test failed due to race condition where the test would finish before the actor had a change to stop. This moves the stop call to the actor, so it's always
called only when the actor actually stops.

One problem with this is that if something breaks on the lib cause the `Actor` to not stop as they should the test would not stop. @JohnTitor would this be a problem on the CI? I'm not sure what problems this would cause. If this is a problem I can add the code bellow to the test so least it's would be easy to see if tests start to break due to timeout, rather than just failing at the stopping count:
```Rust
        actix_rt::spawn(async move {
            delay_for(Duration::from_secs(5)).await;
            panic!("System has not stopped time, are the actors stopping?")
        });
```

fixes #354