### PR TITLE
Add new AtomicResponse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## [TBD] TBD
 
+## Added
+
+* New `AtomicResponse`, a `MessageResponse` with exclusive poll over actor's reference. [#357]
+
 ## Changed
 
 * Require `Pin` for `ResponseActFuture`. [#355]

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -83,9 +83,85 @@ where
 /// ```
 pub struct MessageResult<M: Message>(pub M::Result);
 
+/// A specialized actor future holder for atomic asynchronous message handling.
+///
+/// Intended be used when the future returned will need exclusive access Actor's
+/// internal state or context, e.g., it can yield at critical sessions.
+/// When the actor starts to process this future, it will not pull any other
+/// spawned futures until this one as been completed.
+/// Check [ActorFuture] for available methods for accessing Actor's
+/// internal state.
+///
+/// ## Note
+/// The runtime itself is not blocked in the process, only the Actor,
+/// other futures, and therefore, other actors are still allowed to make
+/// progress when this [AtomicResponse] is used.
+///
+/// # Examples
+/// On the following example, the response to `Msg` would always be 29
+/// even if there are multiple `Msg` sent to `MyActor`.
+/// ```rust, no_run
+/// # use actix::prelude::*;
+/// # use actix::clock::delay_for;
+/// # use std::time::Duration;
+/// #
+/// # #[derive(Message)]
+/// # #[rtype(result = "usize")]
+/// # struct Msg;
+/// #
+/// # struct MyActor(usize);
+/// #
+/// # impl Actor for MyActor {
+/// #    type Context = Context<Self>;
+/// # }
+/// #
+/// impl Handler<Msg> for MyActor {
+///     type Result = AtomicResponse<Self, usize>;
+///
+///     fn handle(&mut self, _: Msg, _: &mut Context<Self>) -> Self::Result {
+///         AtomicResponse::new(Box::pin(
+///             async {}
+///                 .into_actor(self)
+///                 .map(|_, this, _| {
+///                     this.0 = 30;
+///                 })
+///                 .then(|_, this, _| {
+///                     delay_for(Duration::from_secs(3)).into_actor(this)
+///                 })
+///                 .map(|_, this, _| {
+///                     this.0 -= 1;
+///                     this.0
+///                 }),
+///         ))
+///     }
+/// }
+/// ```
+pub struct AtomicResponse<A, T>(ResponseActFuture<A, T>);
+
+impl<A, T> AtomicResponse<A, T> {
+    pub fn new(fut: ResponseActFuture<A, T>) -> Self {
+        AtomicResponse(fut)
+    }
+}
+
+impl<A, M, T: 'static> MessageResponse<A, M> for AtomicResponse<A, T>
+where
+    A: Actor,
+    M: Message<Result = T>,
+    A::Context: AsyncContext<A>,
+{
+    fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>) {
+        ctx.wait(self.0.map(move |res, _, _| {
+            if let Some(tx) = tx {
+                tx.send(res);
+            }
+        }));
+    }
+}
+
 /// A specialized actor future for asynchronous message handling.
 ///
-/// Intended be used from when the future returned will,
+/// Intended be used when the future returned will,
 /// at some point, need to access Actor's internal state or context
 /// in order to finish.
 /// Check [ActorFuture] for available methods for accessing Actor's
@@ -96,6 +172,7 @@ pub struct MessageResult<M: Message>(pub M::Result);
 /// [Context], does not enforce the poll of any [ActorFuture] to be
 /// exclusive. Therefore, if other instances of [ActorFuture] are spawned
 /// into this Context **their execution won't necessarily be atomic**.
+/// Check [AtomicResponse] if you need exclusive access over the actor.
 ///
 /// # Examples
 /// ```rust, no_run
@@ -179,15 +256,16 @@ pub trait ResponseChannel<M: Message>: 'static {
 ///
 /// If `Actor::Context` implements [AsyncContext] it's possible to handle
 /// the message asynchronously.
-/// For asynchronous message handling we offer two possible response types
-/// [ResponseFuture] and [ResponseActFuture].
+/// For asynchronous message handling we offer the following possible response types:
 /// - [ResponseFuture] should be used for when the future returned doesn't
 ///   need to access Actor's internal state or context to progress, either
 ///   because it's completely agnostic to it or because the required data has
 ///   already been moved to it and it won't need Actor state to continue.
-/// - [ResponseActFuture] should be used from when the future returned
+/// - [ResponseActFuture] should be used when the future returned
 ///   will, at some point, need to access Actor's internal state or context
 ///   in order to finish.
+/// - [AtomicResponse] should be used when the future returned needs exclusive
+///   access to  Actor's internal state or context.
 pub trait MessageResponse<A: Actor, M: Message> {
     fn handle<R: ResponseChannel<M>>(self, ctx: &mut A::Context, tx: Option<R>);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,8 @@ pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr};
 pub use crate::context::Context;
 pub use crate::fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};
 pub use crate::handler::{
-    ActorResponse, Handler, Message, MessageResult, Response, ResponseActFuture,
-    ResponseFuture,
+    ActorResponse, AtomicResponse, Handler, Message, MessageResult, Response,
+    ResponseActFuture, ResponseFuture,
 };
 pub use crate::registry::{ArbiterService, Registry, SystemRegistry, SystemService};
 pub use crate::stream::StreamHandler;
@@ -115,8 +115,8 @@ pub mod prelude {
     pub use crate::context::{Context, ContextFutureSpawner};
     pub use crate::fut::{ActorFuture, ActorStream, WrapFuture, WrapStream};
     pub use crate::handler::{
-        ActorResponse, Handler, Message, MessageResult, Response, ResponseActFuture,
-        ResponseFuture,
+        ActorResponse, AtomicResponse, Handler, Message, MessageResult, Response,
+        ResponseActFuture, ResponseFuture,
     };
     pub use crate::registry::{ArbiterService, SystemService};
     pub use crate::stream::StreamHandler;

--- a/tests/test_atomic_response.rs
+++ b/tests/test_atomic_response.rs
@@ -1,0 +1,48 @@
+use actix::clock::delay_for;
+use actix::prelude::*;
+use futures_util::stream::StreamExt;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Message)]
+#[rtype(result = "usize")]
+struct Num(usize);
+
+struct MyActor(usize);
+
+impl Actor for MyActor {
+    type Context = Context<Self>;
+}
+
+impl Handler<Num> for MyActor {
+    type Result = AtomicResponse<Self, usize>;
+
+    fn handle(&mut self, msg: Num, _: &mut Self::Context) -> Self::Result {
+        AtomicResponse::new(Box::pin(
+            delay_for(Duration::from_millis(msg.0 as u64))
+                .into_actor(self)
+                .map(move |_res, this, _| {
+                    this.0 += msg.0;
+                    this.0
+                }),
+        ))
+    }
+}
+
+#[actix_rt::test]
+async fn test_atomic_response() {
+    let items = vec![Num(7), Num(6), Num(5), Num(4), Num(3), Num(2), Num(1)];
+    let addr = MyActor(0).start();
+    let fut = futures_util::stream::iter(items)
+        .map(|i| addr.send(i))
+        .buffer_unordered(7)
+        .fold(Vec::default(), |mut acc, res| {
+            acc.push(res.unwrap());
+            async { acc }
+        });
+
+    let start = Instant::now();
+    let result = fut.await;
+
+    assert!(Instant::now().duration_since(start).as_millis() >= 28);
+    assert_eq!(result, vec![7, 13, 18, 22, 25, 27, 28]);
+}


### PR DESCRIPTION
It has been pointed out and discussed on #308, #334 and on gitter a possible data race when handling messages asynchronously and a note about it has been added to the docs on #326. This offers a easy to use `MessageResponse` to the users that will be spawned into the Actor's context with a `AsyncContext::wait` call.

`AtomicResponse` allows messages responses generated by an `Actor` to have exclusive access over it, making it easier to process messages that need to stop the Actor from processing other futures but still leaving the runtime free to `poll` other spawned futures.

I also removed some unnecessary future wrapping used on other `MessageResponse` implementations.