### PR TITLE
Use `once_cell` over `lazy_static`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/actix/actix.git"
 documentation = "https://docs.rs/actix/"
 categories = ["network-programming", "asynchronous"]
 license = "MIT/Apache-2.0"
-exclude = [".gitignore", ".cargo/config"]
+exclude = [".gitignore", ".cargo/config", ".github/**"]
 edition = "2018"
 
 [badges]
@@ -42,7 +42,7 @@ futures-channel = { version = "0.3.1", default-features = false }
 futures-util = { version = "0.3.1", default-features = false }
 log = "0.4"
 pin-project = "0.4.6"
-lazy_static = "1.4"
+once_cell = "1.3"
 bitflags = "1.2"
 smallvec = "1.0"
 parking_lot = "0.10"

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -10,6 +10,7 @@ use std::default::Default;
 use std::rc::Rc;
 
 use actix_rt::{Arbiter, System};
+use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
 use crate::actor::{Actor, Supervised};
@@ -224,11 +225,8 @@ pub struct SystemRegistry {
     registry: HashMap<TypeId, Box<dyn Any + Send>>,
 }
 
-lazy_static::lazy_static! {
-    static ref SREG: Mutex<HashMap<usize, SystemRegistry>> = {
-        Mutex::new(HashMap::new())
-    };
-}
+static SREG: Lazy<Mutex<HashMap<usize, SystemRegistry>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Trait defines system's service.
 #[allow(unused_variables)]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -141,13 +141,13 @@ where
                     // Let the future's context know that this future might be polled right the way
                     task.waker().wake_by_ref();
                 }
-                return Poll::Pending;
+                Poll::Pending
             }
             Poll::Ready(None) => {
                 A::finished(act, ctx);
-                return Poll::Ready(());
+                Poll::Ready(())
             }
-            Poll::Pending => return Poll::Pending,
+            Poll::Pending => Poll::Pending,
         }
     }
 }


### PR DESCRIPTION
Use `once_cell` over `lazy_static` to acquire macro-free. This adds additional dependency but I'm fine with that since the community seems to prefer `once_cell` nowadays.