### PR TITLE
Only poll dropped ContextFut if event loop is running

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,10 @@
 
 * Update `tokio-util` dependency to 0.3, `FramedWrite` trait bound is changed. [#365]
 
+* Update `actix-rt` dependency to 1.1. [#374]
+
 [#365]: https://github.com/actix/actix/pull/365
+[#374]: https://github.com/actix/actix/pull/374
 
 ## Fixed
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
 
 * Update `tokio-util` dependency to 0.3, `FramedWrite` trait bound is changed. [#365]
 
-* Update `actix-rt` dependency to 1.1. [#374]
+* Only poll dropped ContextFut if event loop is running. [#374]
 
 [#365]: https://github.com/actix/actix/pull/365
 [#374]: https://github.com/actix/actix/pull/374

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ resolver = ["trust-dns-proto", "trust-dns-resolver"]
 mailbox_assert = []
 
 [dependencies]
-actix-rt = "1.0.0"
+actix-rt = "1.1"
 actix_derive = "0.5"
 bytes = "0.5.3"
 crossbeam-channel = "0.4"

--- a/src/contextimpl.rs
+++ b/src/contextimpl.rs
@@ -224,7 +224,7 @@ where
     A: Actor<Context = C>,
 {
     fn drop(&mut self) {
-        if self.alive() {
+        if self.alive() && actix_rt::Arbiter::is_running() {
             self.ctx.parts().stop();
             let waker = futures_util::task::noop_waker();
             let mut cx = futures_util::task::Context::from_waker(&waker);


### PR DESCRIPTION
This ensures the `ContextFut` will not run when dropped if the event loop has already stopped. Which could cause crash in case of the runtime stopping with a spawned actor that didn't fully start.

fixes #372