### PR TITLE
Fix ActorFuture::poll_next impl for StreamThen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@
 
 [#365]: https://github.com/actix/actix/pull/365
 
+## Fixed
+
+* Fix `ActorFuture::poll_next` impl for `StreamThen` to not lose inner future when it's pending. [#376]
+
+[#376]: https://github.com/actix/actix/pull/376
+
 ## [0.10.0-alpha.2] 2020-03-05
 
 ## Added

--- a/src/fut/stream_then.rs
+++ b/src/fut/stream_then.rs
@@ -64,7 +64,7 @@ where
             this.future = Some((this.f)(item, act, ctx).into_future());
         }
         assert!(this.future.is_some());
-        match Pin::new(&mut this.future.take().unwrap()).poll(act, ctx, task) {
+        match Pin::new(this.future.as_mut().unwrap()).poll(act, ctx, task) {
             Poll::Ready(e) => {
                 this.future = None;
                 Poll::Ready(Some(e))

--- a/tests/test_fut.rs
+++ b/tests/test_fut.rs
@@ -56,6 +56,16 @@ impl Actor for MyStreamActor {
 
         s.into_actor(self)
             .timeout(Duration::new(0, 1000))
+            .then(|res, act, _| {
+                // Additional waiting time to test `then` call as well
+                Box::pin(
+                    async move {
+                        delay_for(Duration::from_millis(500)).await;
+                        res
+                    }
+                    .into_actor(act),
+                )
+            })
             .map(|e, act, _| {
                 if let Err(()) = e {
                     act.timeout.store(true, Ordering::Relaxed);


### PR DESCRIPTION
Old implementation would lose the stored future if it wasn't immediately ready
as reported on #375

I've also updated the `test_stream_timeout` to also use the `then` method so we ensure it doesn't break again in the future.

fixes #375 