### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.39.0 # MSRV
+          - 1.40.0 # MSRV
           - stable
           - nightly
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
 
 * Update `tokio-util` dependency to 0.3, `FramedWrite` trait bound is changed. [#365]
 
+* Minimum Rust version is now 1.40 (to be able to use `#[cfg(doctest)]`)
+
 [#365]: https://github.com/actix/actix/pull/365
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Actix is a Rust actors framework.
 * [API Documentation (Development)](https://actix.github.io/actix/actix/)
 * [API Documentation (Releases)](https://docs.rs/actix/)
 * Cargo package: [actix](https://crates.io/crates/actix)
-* Minimum supported Rust version: 1.39 or later
+* Minimum supported Rust version: 1.40 or later
 
 | Platform | Build Status |
 | -------- | ------------ |

--- a/examples/chat/src/client.rs
+++ b/examples/chat/src/client.rs
@@ -97,11 +97,11 @@ impl Handler<ClientCommand> for ChatClient {
         // we check for /sss type of messages
         if m.starts_with('/') {
             let v: Vec<&str> = m.splitn(2, ' ').collect();
-            match v[0] {
-                "/list" => {
+            match v.get(0) {
+                Some(&"/list") => {
                     self.framed.write(codec::ChatRequest::List);
                 }
-                "/join" => {
+                Some(&"/join") => {
                     if v.len() == 2 {
                         self.framed.write(codec::ChatRequest::Join(v[1].to_owned()));
                     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //! * [Chat on gitter](https://gitter.im/actix/actix)
 //! * [GitHub repository](https://github.com/actix/actix)
 //! * [Cargo package](https://crates.io/crates/actix)
-//! * Minimum supported Rust version: 1.39 or later
+//! * Minimum supported Rust version: 1.40 or later
 //!
 //! ## Features
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 #[doc(hidden)]
 pub use actix_derive::*;
 
-#[cfg(test)]
+#[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
 mod actor;


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.