### PR TITLE
buffer write calls in SinkWrite

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ## Changed
 
+* `SinkWrite::write` calls now send all items correctly using an internal buffer. [#384]
+
 * Update `tokio-util` dependency to 0.3, `FramedWrite` trait bound is changed. [#365]
 
 * Only poll dropped ContextFut if event loop is running. [#374]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 ## Changed
 
-* `SinkWrite::write` calls now send all items correctly using an internal buffer. [#384]
+* BREAKING: `SinkWrite::write` calls now send all items correctly using an internal buffer. [#384]
 
 * Update `tokio-util` dependency to 0.3, `FramedWrite` trait bound is changed. [#365]
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,18 @@
 ## 0.10.0
 
-* Calls to `SinkWrite::write` no longer return a Result.
+* `SinkWrite::write` no longer return a Result, instead it returns an
+  `Option<I>` containing the item that had attempted to be sent if the sink is
+  closing or closed.
+
+  Before:
+  ```rust
+  self.sink.write(data).unwrap();
+  ```
+
+  After:
+  ```rust
+  let _ = self.sink.write(data);
+  ```
 
 ## 0.7.9
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,17 +1,21 @@
+## 0.10.0
+
+* Calls to `SinkWrite::write` no longer return a Result.
+
 ## 0.7.9
 
-- `actix` no longer re-exports itself in `actix::prelude` to avoid conflicts with 2018 editions. Please access it through your `extern crate actix` import when necessary
+* `actix` no longer re-exports itself in `actix::prelude` to avoid conflicts with 2018 editions. Please access it through your `extern crate actix` import when necessary
 
 ## 0.7.6
 
-- `trust-dns-resolver` dependency was bumped to version 0.10.0. If you use a
+* `trust-dns-resolver` dependency was bumped to version 0.10.0. If you use a
   custom resolver, you will need to switch your `ResolverConfig` and
   `ResolverOpts` to `trust-dns-resolver` 0.10.0 instead of 0.9.1.
 
 ## 0.7
 
 * `Addr` get refactored. `Syn` and `Unsync` removed. all addresses are
-  `Syn` now, only `Addr<Actor>` exsits
+  `Syn` now, only `Addr<Actor>` exists
 
 * `Arbiter` uses `tokio::runtime::current_thread`
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -448,11 +448,10 @@ impl<I: 'static, S: Sink<I> + Unpin + 'static> SinkWrite<I, S> {
         SinkWrite { inner }
     }
 
-    /// Sends an item to the sink.
-    pub fn write(&mut self, item: I) -> Result<(), S::Error> {
+    /// Queues an item to be sent to the sink.
+    pub fn write(&mut self, item: I) {
         self.inner.borrow_mut().buffer.push_back(item);
         self.notify_task();
-        Ok(())
     }
 
     /// Gracefully closes the sink.
@@ -505,6 +504,7 @@ where
 {
     type Output = ();
     type Actor = A;
+
     fn poll(
         self: Pin<&mut Self>,
         act: &mut A,

--- a/src/io.rs
+++ b/src/io.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::ops::DerefMut;
 use std::pin::Pin;
 use std::rc::Rc;
-use std::{io, task};
+use std::{collections::VecDeque, io, task};
 
 use bitflags::bitflags;
 use bytes::BytesMut;
@@ -436,6 +436,7 @@ impl<I: 'static, S: Sink<I> + Unpin + 'static> SinkWrite<I, S> {
             sink,
             task: None,
             handle: SpawnHandle::default(),
+            buffer: VecDeque::new(),
         }));
 
         let handle = ctxt.spawn(SinkWriteFuture {
@@ -449,11 +450,9 @@ impl<I: 'static, S: Sink<I> + Unpin + 'static> SinkWrite<I, S> {
 
     /// Sends an item to the sink.
     pub fn write(&mut self, item: I) -> Result<(), S::Error> {
-        let res = Pin::new(&mut self.inner.borrow_mut().sink).start_send(item);
-        if let Ok(()) = res {
-            self.notify_task()
-        }
-        res
+        self.inner.borrow_mut().buffer.push_back(item);
+        self.notify_task();
+        Ok(())
     }
 
     /// Gracefully closes the sink.
@@ -487,6 +486,10 @@ struct InnerSinkWrite<I, S: Sink<I>> {
     sink: S,
     task: Option<task::Waker>,
     handle: SpawnHandle,
+
+    // buffer of items to be sent so that multiple
+    // calls to start_send don't silently skip items
+    buffer: VecDeque<I>,
 }
 
 struct SinkWriteFuture<I: 'static, S: Sink<I>, A> {
@@ -510,7 +513,19 @@ where
     ) -> Poll<Self::Output> {
         let this = self.get_mut();
         let inner = &mut this.inner.borrow_mut();
-        inner.task = None;
+
+        // ensure sink is ready to receive next item
+        match Pin::new(&mut inner.sink).poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                if let Some(item) = inner.buffer.pop_front() {
+                    // send front of buffer to sink
+                    let _ = Pin::new(&mut inner.sink).start_send(item);
+                }
+            }
+            Poll::Ready(Err(_err)) => {}
+            Poll::Pending => {}
+        }
+
         if !inner.closing_flag.contains(Flags::CLOSING) {
             match Pin::new(&mut inner.sink).poll_flush(cx) {
                 Poll::Ready(Err(e)) => {
@@ -532,14 +547,18 @@ where
                     }
                 }
                 Poll::Ready(Ok(())) => {
-                    inner.closing_flag |= Flags::CLOSED;
-                    act.finished(ctxt);
-                    return Poll::Ready(());
+                    // ensure all items in buffer have been sent before closing
+                    if inner.buffer.is_empty() {
+                        inner.closing_flag |= Flags::CLOSED;
+                        act.finished(ctxt);
+                        return Poll::Ready(());
+                    }
                 }
                 Poll::Pending => {}
             }
         }
-        inner.task = Some(cx.waker().clone());
+
+        inner.task.replace(cx.waker().clone());
 
         Poll::Pending
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -449,9 +449,16 @@ impl<I: 'static, S: Sink<I> + Unpin + 'static> SinkWrite<I, S> {
     }
 
     /// Queues an item to be sent to the sink.
-    pub fn write(&mut self, item: I) {
-        self.inner.borrow_mut().buffer.push_back(item);
-        self.notify_task();
+    ///
+    /// Returns unsent item if sink is closing or closed.
+    pub fn write(&mut self, item: I) -> Option<I> {
+        if self.inner.borrow().closing_flag.is_empty() {
+            self.inner.borrow_mut().buffer.push_back(item);
+            self.notify_task();
+            None
+        } else {
+            Some(item)
+        }
     }
 
     /// Gracefully closes the sink.

--- a/tests/test_sink.rs
+++ b/tests/test_sink.rs
@@ -92,7 +92,7 @@ impl actix::io::WriteHandler<()> for MyActor {
 impl Handler<Data> for MyActor {
     type Result = ();
     fn handle(&mut self, data: Data, _ctxt: &mut Self::Context) {
-        self.sink.write(data.bytes).unwrap();
+        self.sink.write(data.bytes);
         if data.last {
             self.sink.close();
         }
@@ -205,7 +205,7 @@ impl actix::io::WriteHandler<mpsc::SendError> for AnotherActor {
 impl Handler<Data> for AnotherActor {
     type Result = ();
     fn handle(&mut self, data: Data, _ctxt: &mut Self::Context) {
-        self.sink.write(data.bytes).unwrap();
+        self.sink.write(data.bytes);
         if data.last {
             self.sink.close();
         }

--- a/tests/test_sink.rs
+++ b/tests/test_sink.rs
@@ -92,7 +92,7 @@ impl actix::io::WriteHandler<()> for MyActor {
 impl Handler<Data> for MyActor {
     type Result = ();
     fn handle(&mut self, data: Data, _ctxt: &mut Self::Context) {
-        self.sink.write(data.bytes);
+        let _ = self.sink.write(data.bytes);
         if data.last {
             self.sink.close();
         }
@@ -205,7 +205,8 @@ impl actix::io::WriteHandler<mpsc::SendError> for AnotherActor {
 impl Handler<Data> for AnotherActor {
     type Result = ();
     fn handle(&mut self, data: Data, _ctxt: &mut Self::Context) {
-        self.sink.write(data.bytes);
+        let _ = self.sink.write(data.bytes);
+
         if data.last {
             self.sink.close();
         }


### PR DESCRIPTION
fix actix/actix-web#1479

Moves `Sink::start_send` calls into the ActorFuture impl, and correctly guards with `Sink::poll_ready`, buffering items to be sent.

I think this is the key _(from `futures::sink::Sink::start_send` docs)_:

> Each call to this function must be preceded by a successful call to poll_ready which returned Poll::Ready(Ok(())).

Seems that the easiest way to achieve this is as implemented here; with an item buffer and calling poll_ready in the place where task context is available.

The existing `test_send_2` test seems to adequately test this implementation.
