### PR TITLE
Remove uses of pin_project::project attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ derive_more = "0.99.2"
 futures-channel = { version = "0.3.1", default-features = false }
 futures-util = { version = "0.3.1", default-features = false }
 log = "0.4"
-pin-project = "0.4.6"
+pin-project = "0.4.17"
 once_cell = "1.3"
 bitflags = "1.2"
 smallvec = "1.0"

--- a/src/fut/either.rs
+++ b/src/fut/either.rs
@@ -3,11 +3,11 @@ use std::task::{Context, Poll};
 
 use crate::actor::Actor;
 use crate::fut::ActorFuture;
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 /// Combines two different futures yielding the same item and error
 /// types into a single type.
-#[pin_project]
+#[pin_project(project = EitherProj)]
 #[derive(Debug)]
 pub enum Either<A, B> {
     /// First branch of the type
@@ -58,17 +58,15 @@ where
     type Output = A::Output;
     type Actor = A::Actor;
 
-    #[project]
     fn poll(
         self: Pin<&mut Self>,
         act: &mut A::Actor,
         ctx: &mut <A::Actor as Actor>::Context,
         task: &mut Context<'_>,
     ) -> Poll<A::Output> {
-        #[project]
         match self.project() {
-            Either::Left(x) => x.poll(act, ctx, task),
-            Either::Right(x) => x.poll(act, ctx, task),
+            EitherProj::Left(x) => x.poll(act, ctx, task),
+            EitherProj::Right(x) => x.poll(act, ctx, task),
         }
     }
 }

--- a/src/fut/stream_fold.rs
+++ b/src/fut/stream_fold.rs
@@ -2,7 +2,7 @@ use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use crate::actor::Actor;
 use crate::fut::{ActorFuture, ActorStream, IntoActorFuture};
@@ -61,7 +61,6 @@ where
     type Output = T;
     type Actor = S::Actor;
 
-    #[project]
     fn poll(
         self: Pin<&mut Self>,
         act: &mut S::Actor,

--- a/src/fut/stream_map.rs
+++ b/src/fut/stream_map.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use crate::actor::Actor;
 use crate::fut::ActorStream;
@@ -35,7 +35,6 @@ where
     type Item = U;
     type Actor = S::Actor;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         act: &mut Self::Actor,

--- a/src/fut/stream_then.rs
+++ b/src/fut/stream_then.rs
@@ -1,7 +1,7 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use pin_project::{pin_project, project};
+use pin_project::pin_project;
 
 use crate::actor::Actor;
 use crate::fut::{ActorFuture, ActorStream, IntoActorFuture};
@@ -47,7 +47,6 @@ where
     type Item = U::Output;
     type Actor = S::Actor;
 
-    #[project]
     fn poll_next(
         self: Pin<&mut Self>,
         act: &mut S::Actor,


### PR DESCRIPTION
pin-project will deprecate the project attribute due to some unfixable
limitations.

Refs: https://github.com/taiki-e/pin-project/issues/225

*Although the deprecation of the project attribute has not been released yet, this PR is submitted in advance to avoid the CI from being broken by deprecated warnings.*
