### PR TITLE
Add GroupWeakAddr.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ smallvec = "1.0"
 parking_lot = "0.10"
 tokio = { version = "0.2.6", default-features = false, features = ["rt-core", "rt-util", "io-driver", "io-util", "tcp", "uds", "udp", "time", "signal", "sync"] }
 tokio-util = { version = "0.3", features = ["full"] }
+weak-table = "0.3"
 
 # dns resolver
 trust-dns-proto = { version = "0.19", optional = true, default-features = false, features = ["tokio-runtime"] }

--- a/src/address/group.rs
+++ b/src/address/group.rs
@@ -1,0 +1,214 @@
+use std::hash::Hash;
+use std::ops::Deref;
+
+use crate::actor::Actor;
+use crate::address::envelope::ToEnvelope;
+use crate::address::{Addr, SendError, WeakAddr};
+use crate::handler::{Handler, Message};
+
+use weak_table::{traits::WeakElement, PtrWeakHashSet};
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+struct WeakTableAddrWrap<A: Actor>(Addr<A>);
+
+impl<A: Actor> Deref for WeakTableAddrWrap<A> {
+    type Target = Addr<A>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Debug)]
+struct WeakTableWeakAddrWrap<A: Actor>(WeakAddr<A>);
+
+impl<A: Actor> Deref for WeakTableWeakAddrWrap<A> {
+    type Target = WeakAddr<A>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<A: Actor> WeakElement for WeakTableWeakAddrWrap<A> {
+    type Strong = WeakTableAddrWrap<A>;
+
+    fn new(view: &Self::Strong) -> Self {
+        WeakTableWeakAddrWrap(view.0.downgrade())
+    }
+
+    fn view(&self) -> Option<Self::Strong> {
+        self.upgrade().map(|addr| WeakTableAddrWrap(addr))
+    }
+}
+
+impl<A: Actor> Clone for WeakTableWeakAddrWrap<A> {
+    fn clone(&self) -> WeakTableWeakAddrWrap<A> {
+        WeakTableWeakAddrWrap(self.0.clone())
+    }
+}
+
+/// A group of actors that doesn't extend the actors lifetime. This uses `WeakAddrs` inside.
+///
+/// You can use this to send messages to a group of actors (at least to the ones which are still alive).
+#[derive(Debug)]
+pub struct GroupWeakAddr<A: Actor> {
+    set: PtrWeakHashSet<WeakTableWeakAddrWrap<A>>,
+}
+
+impl<A: Actor> Clone for GroupWeakAddr<A> {
+    fn clone(&self) -> GroupWeakAddr<A> {
+        GroupWeakAddr {
+            set: self.set.clone(),
+        }
+    }
+}
+
+pub struct GroupWeakAddrIterator<'a, A: Actor>(
+    weak_table::ptr_weak_hash_set::Iter<'a, WeakTableWeakAddrWrap<A>>,
+);
+
+impl<'a, A: Actor> core::iter::Iterator for GroupWeakAddrIterator<'a, A> {
+    type Item = Addr<A>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|weakwrapper| weakwrapper.deref().clone())
+    }
+}
+
+impl<'a, A: Actor> IntoIterator for &'a GroupWeakAddr<A> {
+    type Item = Addr<A>;
+    type IntoIter = GroupWeakAddrIterator<'a, A>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<A: Actor> PartialEq for GroupWeakAddr<A> {
+    fn eq(&self, other: &Self) -> bool {
+        self.set == other.set
+    }
+}
+
+impl<A: Actor> Eq for GroupWeakAddr<A> {}
+
+impl<A: Actor> GroupWeakAddr<A> {
+    pub fn new() -> Self {
+        GroupWeakAddr {
+            set: weak_table::PtrWeakHashSet::new(),
+        }
+    }
+
+    /// Get an iterator for the elements.
+    pub fn iter<'a>(&'a self) -> GroupWeakAddrIterator<'a, A> {
+        GroupWeakAddrIterator(self.set.iter())
+    }
+
+    /// Removes all actors which have expired.
+    pub fn remove_expired(&mut self) {
+        self.set.remove_expired()
+    }
+
+    /// Returns the number of elements the group can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.set.capacity()
+    }
+
+    /// Reserves room for additional elements.
+    pub fn reserve(&mut self, additional_capacity: usize) {
+        self.set.reserve(additional_capacity)
+    }
+
+    /// Shrinks the capacity to the minimum allowed to hold the current number of elements.
+    pub fn shrink_to_fit(&mut self) {
+        self.set.shrink_to_fit()
+    }
+
+    /// Returns an over-approximation of the number of elements.
+    pub fn len(&self) -> usize {
+        self.set.len()
+    }
+
+    /// Is the set known to be empty?
+    ///
+    /// This could answer `false` for an empty set whose elements have
+    /// expired but have yet to be collected.
+    pub fn is_empty(&self) -> bool {
+        self.set.is_empty()
+    }
+
+    /// The proportion of buckets that are used.
+    ///
+    /// This is an over-approximation because of expired elements.
+    pub fn load_factor(&self) -> f32 {
+        self.set.load_factor()
+    }
+
+    /// Removes all actors from the group.
+    pub fn clear(&mut self) {
+        self.set.clear()
+    }
+
+    /// Returns true if the group contains the specified addr.
+    pub fn contains(&self, key: &Addr<A>) -> bool {
+        self.set.contains(&WeakTableAddrWrap(key.clone()))
+    }
+
+    /// Unconditionally inserts the addr, returning true if already present.
+    pub fn insert(&mut self, key: Addr<A>) -> bool {
+        self.set.insert(WeakTableAddrWrap(key))
+    }
+
+    /// Removes the addr, and returns true if it was present in this group.
+    pub fn remove(&mut self, key: &Addr<A>) -> bool {
+        self.set.remove(&WeakTableAddrWrap(key.clone()))
+    }
+
+    /// Removes all addrs not satisfying the given predicate.
+    ///
+    /// Also removes any expired actors.
+    pub fn retain<F>(&mut self, mut f: F)
+    where
+        F: FnMut(Addr<A>) -> bool,
+    {
+        self.set
+            .retain(|k: WeakTableAddrWrap<A>| f(k.deref().clone()))
+    }
+
+    /// Is self a subset of other?
+    pub fn is_subset(&self, other: &GroupWeakAddr<A>) -> bool {
+        self.set.is_subset(&other.set)
+    }
+
+    #[inline]
+    /// Sends a message unconditionally, ignoring any potential errors.
+    ///
+    /// The message is always queued, even if the mailbox for the receiver is full.
+    /// If the mailbox is closed, the message is silently dropped.
+    pub fn do_send<M>(&self, msg: M)
+    where
+        M: Message + Send + Clone,
+        M::Result: Send,
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
+    {
+        self.iter().for_each(|addr| {
+            addr.do_send(msg.clone());
+        });
+    }
+
+    /// Tries to send a message.
+    ///
+    /// This method fails if an actor's mailbox is full or closed. This
+    /// method registers the current task in the receiver's queue.
+    pub fn try_send<M>(&self, msg: M) -> Result<(), SendError<M>>
+    where
+        M: Message + Send + Clone + 'static,
+        M::Result: Send,
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
+    {
+        self.iter()
+            .map(|addr| addr.try_send(msg.clone()))
+            .fold(Ok(()), |acc, result| acc.and_then(|()| result))
+    }
+}

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -5,8 +5,11 @@ use derive_more::Display;
 
 pub(crate) mod channel;
 mod envelope;
+mod group;
 mod message;
 mod queue;
+
+pub use group::{GroupWeakAddr, GroupWeakAddrIterator};
 
 use crate::actor::Actor;
 use crate::handler::{Handler, Message};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,9 @@ pub use actix_rt::{Arbiter, System, SystemRunner};
 pub use crate::actor::{
     Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
 };
-pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr};
+pub use crate::address::{
+    Addr, GroupWeakAddr, GroupWeakAddrIterator, MailboxError, Recipient, WeakAddr,
+};
 // pub use crate::arbiter::{Arbiter, ArbiterBuilder};
 pub use crate::context::Context;
 pub use crate::fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};
@@ -110,7 +112,8 @@ pub mod prelude {
         Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
     };
     pub use crate::address::{
-        Addr, MailboxError, Recipient, RecipientRequest, Request, SendError,
+        Addr, GroupWeakAddr, GroupWeakAddrIterator, MailboxError, Recipient,
+        RecipientRequest, Request, SendError,
     };
     pub use crate::context::{Context, ContextFutureSpawner};
     pub use crate::fut::{ActorFuture, ActorStream, WrapFuture, WrapStream};


### PR DESCRIPTION
This is useful for when you might have some group of "sibilings" of "child" actors that you want to notify, but don't want to extend their lifetime by holding an `Addr` of them.

Example could be when you have a `Listener`/`Server` which for a particular message/event creates a "child" actor.

The "child" actors could have a shorter lifespan than the `Listener` but they shouldn't outlive the `Listener`. In that case the `Listener` might want to store `WeakAddr`s for all of the "child" actors created and upon stopping it will send a message to all still existing "child" to notify them that they must shut down.

The reason for the pull request is that for this purpose you cannot use a simple `HashSet<WeakAddr<A>>` because `WeakAddr` doesn't (and cannot easily) implement `Hash` and `Eq`.

This PR's `GroupWeakAddr` internally uses the `PtrWeakHashSet` from the external crate `weak_table`.

All reviews are welcome. I am particularly uncertain about what is the best name for this struct so all suggestions are appreciated.