### PR TITLE
Make `Request` `Send` regardless of actor type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 [#384]: https://github.com/actix/actix/pull/384
 [#403]: https://github.com/actix/actix/pull/403
 [#404]: https://github.com/actix/actix/pull/404
+[#407]: https://github.com/actix/actix/pull/407
 
 ## [0.10.0-alpha.3] - 2020-05-13
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@
 
 * Update `parking_lot` to 0.11 [#404]
 
+* Remove unnecessary `PhantomData` field from `Request` making it `Send + Sync`
+  regardless if `Request`'s type-argument is `Send` or `Sync` [#407]
+
 [#384]: https://github.com/actix/actix/pull/384
 [#403]: https://github.com/actix/actix/pull/403
 [#404]: https://github.com/actix/actix/pull/404

--- a/src/address/message.rs
+++ b/src/address/message.rs
@@ -1,5 +1,4 @@
 use std::future::Future;
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{self, Poll};
 use std::time::Duration;
@@ -27,7 +26,6 @@ where
     rx: Option<oneshot::Receiver<M::Result>>,
     info: Option<(AddressSender<A>, M)>,
     timeout: Option<Delay>,
-    act: PhantomData<A>,
 }
 
 impl<A, M> Request<A, M>
@@ -44,7 +42,6 @@ where
             rx,
             info,
             timeout: None,
-            act: PhantomData,
         }
     }
 


### PR DESCRIPTION
Removes `Request`'s `PhantomData<A>` field, as `A` is already constrained in `Request` (there is a `AddressSender<A>` field) and `PhantomData` just seems to be overlooked during previous `Request` refactoring.

<details>
<summary>HISTORY</summary>

Changes `Request`'s `PhantomData<A>` to `PhantomData<AtomicPtr<A>>` (which is always `Send` and `Sync`), which makes `Request` auto implement `Send` and `Sync` regardless if `A` is `Send` or `Sync`.

</details>

Fixes #405.