### PR TITLE
Check code with rustfmt not to introduce format commits

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+<!-- Thanks for considering contributing actix! -->
+<!-- Please fill out the following to make our reviews easy. -->
+
 ## PR Type
 <!-- What kind of change does this PR make? -->
 <!-- Bug Fix / Feature / Refactor / Code Style / Other -->
@@ -12,6 +15,7 @@ Check your PR fulfills the following:
 - [ ] Tests for the changes have been added / updated.
 - [ ] Documentation comments have been added / updated.
 - [ ] A changelog entry has been made for the appropriate packages.
+- [ ] Format code with the latest stable rustfmt
 
 
 ## Overview

--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -2,18 +2,31 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-name: Clippy Check
+name: Clippy and rustfmt Check
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          components: rustfmt
+          override: true
+      - name: Check with rustfmt
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: clippy
           override: true
-      - uses: actions-rs/clippy-check@v1
+      - name: Check with Clippy
+        uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all --tests


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Chore

## Overview

Currently, we don't force contributors to format their PRs. I think it's worth checking code with rustfmt on CI since an unspecified number of people may touch the code and formatting commit is noisy to follow commit history.
I use stable rustfmt here for two reasons:
- nightly rustfmt enables unstable rules.
- nightly rustfmt is sometimes broken as it's managed as submodule rather than subtree like Clippy.