### PR TITLE
add `WeakRecipient<M>`

### DIFF
--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -32,6 +32,8 @@ where
 
     fn boxed(&self) -> Box<dyn Sender<M> + Sync>;
 
+    fn arced(&self) -> Arc<dyn Sender<M> + Sync>;
+
     fn hash(&self) -> usize;
 
     fn connected(&self) -> bool;
@@ -467,6 +469,9 @@ where
     }
     fn boxed(&self) -> Box<dyn Sender<M> + Sync> {
         Box::new(self.clone())
+    }
+    fn arced(&self) -> Arc<dyn Sender<M> + Sync> {
+        Arc::new(self.clone())
     }
 
     fn hash(&self) -> usize {

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -1,5 +1,5 @@
 use std::hash::{Hash, Hasher};
-use std::{error, fmt};
+use std::{error, fmt, sync::Arc};
 
 use derive_more::Display;
 
@@ -220,7 +220,7 @@ where
     M: Message + Send,
     M::Result: Send,
 {
-    tx: Box<dyn Sender<M> + Sync>,
+    tx: Arc<dyn Sender<M> + Sync>,
 }
 
 impl<M> Recipient<M>
@@ -229,7 +229,7 @@ where
     M::Result: Send,
 {
     /// Creates a new recipient.
-    pub(crate) fn new(tx: Box<dyn Sender<M> + Sync>) -> Recipient<M> {
+    pub(crate) fn new(tx: Arc<dyn Sender<M> + Sync>) -> Recipient<M> {
         Recipient { tx }
     }
 
@@ -276,7 +276,7 @@ where
     A::Context: ToEnvelope<A, M>,
 {
     fn into(self) -> Recipient<M> {
-        Recipient::new(Box::new(self.tx))
+        Recipient::new(Arc::new(self.tx))
     }
 }
 
@@ -287,7 +287,7 @@ where
 {
     fn clone(&self) -> Recipient<M> {
         Recipient {
-            tx: self.tx.boxed(),
+            tx: self.tx.arced(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use actix_rt::{Arbiter, System, SystemRunner};
 pub use crate::actor::{
     Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
 };
-pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr};
+pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr, WeakRecipient};
 // pub use crate::arbiter::{Arbiter, ArbiterBuilder};
 pub use crate::context::Context;
 pub use crate::fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Hi there,
I'm trying to convert my project to make greater use of `Recipient<M>` instead of `Addr<A>` since I believe it allows to loosen some tight coupling here and there. Unfortunately there is no equivalent to `WeakAddr<A>` for Recipients yet, so I cannot really use Recipents at the moment without running the risk of leaking objects.
Therefore I would like to suggest adding `WeakRecipients` to actix.

Thank you