### PR TITLE
Remove the Unpin requirement on Response::fut()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,13 @@
 * Remove unnecessary `PhantomData` field from `Request` making it `Send + Sync`
   regardless if `Request`'s type-argument is `Send` or `Sync` [#407]
 
+* The `where` clause on `Response::fut()` was relaxed to no longer require `T: Unpin`, allowing a `Response` to be created with an `async` block [#421]
+
 [#384]: https://github.com/actix/actix/pull/384
 [#403]: https://github.com/actix/actix/pull/403
 [#404]: https://github.com/actix/actix/pull/404
 [#407]: https://github.com/actix/actix/pull/407
+[#421]: https://github.com/actix/actix/pull/421
 
 ## [0.10.0-alpha.3] - 2020-05-13
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -441,7 +441,7 @@ where
 
 enum ResponseTypeItem<I, E> {
     Result(Result<I, E>),
-    Fut(Box<dyn Future<Output = Result<I, E>> + Unpin>),
+    Fut(Pin<Box<dyn Future<Output = Result<I, E>>>>),
 }
 
 /// Helper type for representing different type of message responses
@@ -464,10 +464,10 @@ impl<I, E> Response<I, E> {
     /// Creates an asynchronous response.
     pub fn fut<T>(fut: T) -> Self
     where
-        T: Future<Output = Result<I, E>> + Unpin + 'static,
+        T: Future<Output = Result<I, E>> + 'static,
     {
         Self {
-            item: ResponseTypeItem::Fut(Box::new(fut)),
+            item: ResponseTypeItem::Fut(Box::pin(fut)),
         }
     }
 


### PR DESCRIPTION
# PR Type

This is a *Feature* -  it allows users to write code that they previously couldn't due to an overly strict `where` clause.

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt

## Overview

This PR removes a the `Unpin` requirement from the `Response::fut()` constructor's `where` clause, allowing a `Response` to be constructed using an `async` block or result of an `async` function. 

Previously, a `Response` could only be constructed via combinators (`futures::FutureExt` and friends) and using an `async` block would result in a type error.

This should be fully backwards compatible because: 

1. Any type that is `T: Future + Unpin + 'static` is also `T: Future + 'static`
2. The user can't directly access the `ResponseTypeItem::Fut` variant. So they won't know it's changed from `Box<dyn Future>` to `Pin<Box<dyn Future>>`
