### PR TITLE
move derive crate into workspace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,14 @@
 ### Fixed
 * Fix error for build with --no-default-features flag, add `sink` feature for futures-util dependency. [#427]
 
+### Changed
+* The re-exported `actix-derive` macros are now conditionally included with the `derive` feature
+  which is enabled by default but can be switched off to reduce dependencies. [#424]
+* The `where` clause on `Response::fut()` was relaxed to no longer require `T: Unpin`, allowing a
+  `Response` to be created with an `async` block [#421]
+
+[#421]: https://github.com/actix/actix/pull/421
+[#424]: https://github.com/actix/actix/pull/424
 [#427]: https://github.com/actix/actix/pull/427
 
 
@@ -15,13 +23,10 @@
 * Remove unnecessary `PhantomData` field from `Request` making it `Send + Sync` regardless if
   `Request`'s type-argument is `Send` or `Sync` [#407]
 
-* The `where` clause on `Response::fut()` was relaxed to no longer require `T: Unpin`, allowing a `Response` to be created with an `async` block [#421]
-
 [#384]: https://github.com/actix/actix/pull/384
 [#403]: https://github.com/actix/actix/pull/403
 [#404]: https://github.com/actix/actix/pull/404
 [#407]: https://github.com/actix/actix/pull/407
-[#421]: https://github.com/actix/actix/pull/421
 
 
 ## 0.10.0-alpha.3 - 2020-05-13

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,29 @@ license = "MIT OR Apache-2.0"
 exclude = [".gitignore", ".cargo/config", ".github/**", "codecov.yml"]
 edition = "2018"
 
+[workspace]
+members = [".", "actix-derive", "examples/chat"]
+
 [lib]
 name = "actix"
 path = "src/lib.rs"
 
-[workspace]
-members = ["examples/chat"]
-
 [features]
-default = ["resolver"]
+default = ["resolver", "derive"]
 
 # DNS resolver
 resolver = ["trust-dns-proto", "trust-dns-resolver"]
+
+# Re-exports derive macros from actix-derive
+derive = ["actix_derive"]
 
 # Adds assertion to prevent processing too many messages on event loop
 mailbox_assert = []
 
 [dependencies]
 actix-rt = "1.1.1"
-actix_derive = "0.5"
+actix_derive = { version = "0.5", optional = true }
+
 bytes = "0.5.3"
 crossbeam-channel = "0.4"
 derive_more = "0.99.2"
@@ -57,3 +61,7 @@ doc-comment = "0.3"
 lto = true
 opt-level = 3
 codegen-units = 1
+
+[patch.crates-io]
+actix = { path = "." }
+actix_derive = { path = "actix-derive" }

--- a/actix-derive/CHANGES.md
+++ b/actix-derive/CHANGES.md
@@ -1,0 +1,39 @@
+# Changes
+
+## 0.5.0 (2019-10-27
+* Update syn & quote to 1.0
+
+
+## 0.4.0 (2019-03-12)
+* Added `MessageResponse` proc derive macro
+
+
+## 0.3.2 (2018-11-04)
+* Fix another warning in rustc 1.29 or later [#12]
+
+
+## 0.3.1 (2018-10-28)
+* Upgrade `syn` crate to 0.15
+
+
+## 0.3.0 (2018-07-20)
+* Fix warning in rustc 1.29.0-nightly [#9]
+* Remove nightly support
+
+
+## 0.2.0 (2018-02-xx)
+* Actix 0.5 support
+
+
+## 0.1.1 (2017-12-23)
+* Move tests to actix
+
+
+## 0.1.0 (2017-12-23)
+* Added `msg` proc macro
+* Added `actor` proc macro
+
+<!-- PR Links -->
+
+[#12]: https://github.com/actix/actix-derive/pull/12
+[#9]: https://github.com/actix/actix-derive/pull/9

--- a/actix-derive/Cargo.toml
+++ b/actix-derive/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "actix_derive"
+version = "0.5.0"
+edition = "2018"
+authors = ["Callym <hi@callym.com>", "Nikolay Kim <fafhrd91@gmail.com>"]
+description = "Derive macros for `actix` actors"
+readme = "README.md"
+keywords = ["actix", "actors", "derive", "macro"]
+homepage = "https://github.com/actix/actix-derive/"
+repository = "https://github.com/actix/actix-derive.git"
+documentation = "https://docs.rs/actix-derive/"
+license = "MIT OR Apache-2.0"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = { version = "1", features = ["full"] }
+proc-macro2 = "1"
+
+[dev-dependencies]
+actix = { version = "0.10", default-features = false }

--- a/actix-derive/LICENSE-APACHE
+++ b/actix-derive/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/actix-derive/LICENSE-MIT
+++ b/actix-derive/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/actix-derive/README.md
+++ b/actix-derive/README.md
@@ -1,0 +1,65 @@
+# actix-derive
+
+> Derive macros for `actix` actors.
+
+[![Build Status](https://travis-ci.org/actix/actix-derive.svg?branch=master)](https://travis-ci.org/actix/actix-derive)
+[![crates.io](https://img.shields.io/crates/v/actix-derive)](https://crates.io/crates/actix-derive)
+
+- [API Documentation](https://docs.rs/actix-derive/)
+- Cargo package: [actix](https://crates.io/crates/actix-derive)
+
+## Usage
+
+```rust
+use actix_derive::{Message, MessageResponse};
+
+#[derive(MessageResponse)]
+struct Added(usize);
+
+#[derive(Message)]
+#[rtype(result = "Added")]
+struct Sum(usize, usize);
+
+fn main() {}
+```
+
+This code expands into following code:
+
+```rust
+use actix::{Actor, Context, Handler, System};
+use actix_derive::{Message, MessageResponse};
+
+#[derive(MessageResponse)]
+struct Added(usize);
+
+#[derive(Message)]
+#[rtype(result = "Added")]
+struct Sum(usize, usize);
+
+#[derive(Default)]
+struct Adder;
+
+impl Actor for Adder {
+    type Context = Context<Self>;
+}
+
+impl Handler<Sum> for Adder {
+    type Result = <Sum as actix::Message>::Result;
+    fn handle(&mut self, msg: Sum, _: &mut Self::Context) -> Added {
+        Added(msg.0 + msg.1)
+    }
+}
+
+fn main() {}
+```
+
+## License
+
+This project is licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
+  https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or
+  https://opensource.org/licenses/MIT)
+
+at your option.

--- a/actix-derive/rustfmt.toml
+++ b/actix-derive/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 89
+reorder_imports = true

--- a/actix-derive/src/lib.rs
+++ b/actix-derive/src/lib.rs
@@ -1,0 +1,23 @@
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use syn::DeriveInput;
+
+mod message;
+mod message_response;
+
+#[proc_macro_derive(Message, attributes(rtype))]
+pub fn message_derive_rtype(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    message::expand(&ast).into()
+}
+
+#[proc_macro_derive(MessageResponse)]
+pub fn message_response_derive_rtype(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    message_response::expand(&ast).into()
+}

--- a/actix-derive/src/message.rs
+++ b/actix-derive/src/message.rs
@@ -1,0 +1,107 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{quote, ToTokens};
+
+pub const MESSAGE_ATTR: &str = "rtype";
+
+pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
+    let item_type = {
+        match get_attribute_type_multiple(ast, MESSAGE_ATTR) {
+            Ok(ty) => match ty.len() {
+                1 => ty[0].clone(),
+                _ => {
+                    return syn::Error::new(
+                        Span::call_site(),
+                        format!(
+                            "#[{}(type)] takes 1 parameters, given {}",
+                            MESSAGE_ATTR,
+                            ty.len()
+                        ),
+                    )
+                    .to_compile_error()
+                }
+            },
+            Err(err) => return err.to_compile_error(),
+        }
+    };
+
+    let name = &ast.ident;
+    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let item_type = item_type
+        .map(ToTokens::into_token_stream)
+        .unwrap_or_else(|| quote! { () });
+
+    quote! {
+        impl #impl_generics ::actix::Message for #name #ty_generics #where_clause {
+            type Result = #item_type;
+        }
+    }
+}
+
+fn get_attribute_type_multiple(
+    ast: &syn::DeriveInput,
+    name: &str,
+) -> syn::Result<Vec<Option<syn::Type>>> {
+    let attr = ast
+        .attrs
+        .iter()
+        .find_map(|a| {
+            let a = a.parse_meta();
+            match a {
+                Ok(meta) => {
+                    if meta.path().is_ident(name) {
+                        Some(meta)
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            }
+        })
+        .ok_or_else(|| {
+            syn::Error::new(Span::call_site(), format!("Expect a attribute `{}`", name))
+        })?;
+
+    if let syn::Meta::List(ref list) = attr {
+        Ok(list
+            .nested
+            .iter()
+            .map(|m| meta_item_to_ty(m).ok())
+            .collect())
+    } else {
+        return Err(syn::Error::new_spanned(
+            attr,
+            format!("The correct syntax is #[{}(type, type, ...)]", name),
+        ));
+    }
+}
+
+fn meta_item_to_ty(meta_item: &syn::NestedMeta) -> syn::Result<syn::Type> {
+    match meta_item {
+        syn::NestedMeta::Meta(syn::Meta::Path(ref path)) => match path.get_ident() {
+            Some(ident) => syn::parse_str::<syn::Type>(&ident.to_string())
+                .map_err(|_| syn::Error::new_spanned(ident, "Expect type")),
+            None => Err(syn::Error::new_spanned(path, "Expect type")),
+        },
+        syn::NestedMeta::Meta(syn::Meta::NameValue(val)) => match val.path.get_ident() {
+            Some(ident) if ident == "result" => {
+                if let syn::Lit::Str(ref s) = val.lit {
+                    if let Ok(ty) = syn::parse_str::<syn::Type>(&s.value()) {
+                        return Ok(ty);
+                    }
+                }
+                Err(syn::Error::new_spanned(&val.lit, "Expect type"))
+            }
+            _ => Err(syn::Error::new_spanned(
+                &val.lit,
+                r#"Expect `result = "TYPE"`"#,
+            )),
+        },
+        syn::NestedMeta::Lit(syn::Lit::Str(ref s)) => {
+            syn::parse_str::<syn::Type>(&s.value())
+                .map_err(|_| syn::Error::new_spanned(s, "Expect type"))
+        }
+
+        meta => Err(syn::Error::new_spanned(meta, "Expect type")),
+    }
+}

--- a/actix-derive/src/message_response.rs
+++ b/actix-derive/src/message_response.rs
@@ -1,0 +1,26 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse_quote;
+
+pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let (_, ty_generics, where_clause) = ast.generics.split_for_impl();
+
+    let mut generics = ast.generics.clone();
+    generics.params.push(parse_quote!(_A: actix::Actor));
+    generics
+        .params
+        .push(parse_quote!(_M: actix::Message<Result = #name #ty_generics>));
+    let (impl_generics, _, _) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics ::actix::dev::MessageResponse<_A, _M> for #name #ty_generics #where_clause {
+            fn handle<R: actix::dev::ResponseChannel<_M>>(self, _: &mut _A::Context, tx: Option<R>) {
+                if let Some(tx) = tx {
+                    tx.send(self);
+                }
+            }
+        }
+    }
+}

--- a/actix-derive/tests/test_macro.rs
+++ b/actix-derive/tests/test_macro.rs
@@ -1,0 +1,31 @@
+use actix::{Actor, Context, Handler, System};
+use actix_derive::{Message, MessageResponse};
+
+#[derive(MessageResponse)]
+struct Added(usize);
+
+#[derive(Message)]
+#[rtype(result = "Added")]
+struct Sum(usize, usize);
+
+#[derive(Default)]
+struct Adder;
+
+impl Actor for Adder {
+    type Context = Context<Self>;
+}
+
+impl Handler<Sum> for Adder {
+    type Result = <Sum as actix::Message>::Result;
+    fn handle(&mut self, msg: Sum, _: &mut Self::Context) -> Added {
+        Added(msg.0 + msg.1)
+    }
+}
+
+#[test]
+fn test_message() {
+    let mut sys = System::new("actix-test-runtime");
+    let addr = Adder::start_default();
+    let res = sys.block_on(addr.send(Sum(3, 5))).unwrap();
+    assert_eq!(res.0, 8);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
 #![warn(deprecated_in_future, trivial_casts, trivial_numeric_casts)]
 
 #[doc(hidden)]
+#[cfg(feature = "derive")]
 pub use actix_derive::*;
 
 #[cfg(doctest)]
@@ -101,7 +102,9 @@ pub mod prelude {
     //! ```
 
     #[doc(hidden)]
+    #[cfg(feature = "derive")]
     pub use actix_derive::*;
+
     pub use actix_rt::{Arbiter, System, SystemRunner};
 
     pub use crate::actor::{


### PR DESCRIPTION
## PR Type
Meta / Organisation

## Overview
I often forget that actix-derive exists since it's in a separate repo. This way we can archive the old repo and keep track of the crate more easily.