### PR TITLE
Add WeakRecipient (v2)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,12 @@
   which is enabled by default but can be switched off to reduce dependencies. [#424]
 * The `where` clause on `Response::fut()` was relaxed to no longer require `T: Unpin`, allowing a
   `Response` to be created with an `async` block [#421]
+* Allow creating `WeakRecipient` from `WeakAddr`, similiar to `Recipient` from `Addr`. [#432]
 
 [#421]: https://github.com/actix/actix/pull/421
 [#424]: https://github.com/actix/actix/pull/424
 [#427]: https://github.com/actix/actix/pull/427
+[#432]: https://github.com/actix/actix/pull/432
 
 
 ## 0.10.0 - 2020-09-10

--- a/examples/weak_addr.rs
+++ b/examples/weak_addr.rs
@@ -1,0 +1,128 @@
+//! WeakAddr example
+//!
+//! With a weak address you can register an client actor's addrs with a
+//! service and still get cleaned up correctly when the client actor is
+//! stopped. Alternatively you'd have to check if the client's mailbox
+//! is still open.
+
+use actix::{prelude::*, WeakAddr};
+use actix::{Actor, Context};
+
+use std::time::{Duration, Instant};
+
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub struct TimePing(Instant);
+
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub struct RegisterForTime(pub WeakAddr<Client>);
+
+#[derive(Debug, Default)]
+pub struct TimeService {
+    clients: Vec<WeakAddr<Client>>,
+}
+
+impl TimeService {
+    fn send_tick(&mut self, _ctx: &mut Context<Self>) {
+        for client in self.clients.iter() {
+            if let Some(client) = client.upgrade() {
+                client.do_send(TimePing(Instant::now()));
+                println!("⏰ sent ping to client {:?}", client);
+            } else {
+                println!("⏰ client can no longer be upgraded");
+            }
+        }
+
+        // gc
+        self.clients = self
+            .clients
+            .drain(..)
+            .filter(|c| c.upgrade().is_some())
+            .collect();
+        println!("⏰ service has {} clients", self.clients.len());
+    }
+}
+
+impl Actor for TimeService {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("⏰ starting TimeService");
+        ctx.run_interval(Duration::from_millis(1_000), Self::send_tick);
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        println!("⏰ stopping TimeService");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        println!("⏰ stopped TimeService");
+    }
+}
+
+impl Handler<RegisterForTime> for TimeService {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        RegisterForTime(client): RegisterForTime,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        println!("⏰ received registration");
+        self.clients.push(client);
+    }
+}
+
+impl Supervised for TimeService {}
+impl SystemService for TimeService {}
+
+#[derive(Debug, Default)]
+pub struct Client;
+
+impl Actor for Client {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("🐰 starting Client");
+        TimeService::from_registry()
+            .send(RegisterForTime(ctx.address().downgrade()))
+            .into_actor(self)
+            .then(|_, _slf, _| fut::ready(()))
+            .spawn(ctx);
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        println!("🐰 stopping Client");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        println!("🐰 stopped Client");
+    }
+}
+
+impl Handler<TimePing> for Client {
+    type Result = ();
+
+    fn handle(&mut self, msg: TimePing, _ctx: &mut Self::Context) -> Self::Result {
+        println!("🐰 client received ping: {:?}", msg);
+    }
+}
+
+#[actix_rt::main]
+async fn main() {
+    {
+        println!("🎩 creating client client");
+        let _client = Client.start();
+
+        println!("🎩 press Ctrl-C to stop client");
+        tokio::signal::ctrl_c().await.unwrap();
+        println!("🎩 Ctrl-C received, stopping client");
+    }
+
+    tokio::signal::ctrl_c().await.unwrap();
+    println!("🎩 Ctrl-C received, shutting down");
+    System::current().stop();
+}

--- a/examples/weak_recipient.rs
+++ b/examples/weak_recipient.rs
@@ -1,0 +1,178 @@
+//! WeakRecipient example
+//!
+//! With a weak recipent you can register any client actor's addrs with a
+//! service and still get cleaned up correctly when the client actor is
+//! stopped. In contrast to a `WeakAddr` the Service is not bound to know
+//! exactly which type of client actor is registring itself.
+
+use actix::{prelude::*, WeakRecipient};
+use actix::{Actor, Context};
+
+use std::time::{Duration, Instant};
+
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub struct TimePing(Instant);
+
+#[derive(Message, Debug)]
+#[rtype(result = "()")]
+pub struct RegisterForTime(pub WeakRecipient<TimePing>);
+
+#[derive(Debug)]
+pub struct TimeService {
+    clients: Vec<WeakRecipient<TimePing>>,
+}
+
+impl TimeService {
+    fn send_tick(&mut self, _ctx: &mut Context<Self>) {
+        for client in self.clients.iter() {
+            if let Some(client) = client.upgrade() {
+                // `Recipient::do_send` seems inconsistent with `Addr::do_send`
+                client.do_send(TimePing(Instant::now())).unwrap();
+                println!("⏰ sent ping to client {:?}", client);
+            } else {
+                println!("⏰ client can no longer be upgraded");
+            }
+        }
+
+        // gc
+        self.clients = self
+            .clients
+            .drain(..)
+            .filter(|c| c.upgrade().is_some())
+            .collect();
+        println!("⏰ service has {} clients", self.clients.len());
+    }
+}
+
+impl Actor for TimeService {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("⏰ starting TimeService");
+        ctx.run_interval(Duration::from_millis(1_000), Self::send_tick);
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        println!("⏰ stopping TimeService");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        println!("⏰ stopped TimeService");
+    }
+}
+
+impl Handler<RegisterForTime> for TimeService {
+    type Result = ();
+
+    fn handle(
+        &mut self,
+        RegisterForTime(client): RegisterForTime,
+        _ctx: &mut Self::Context,
+    ) -> Self::Result {
+        println!("⏰ received registration");
+        self.clients.push(client);
+    }
+}
+
+impl Supervised for TimeService {}
+impl SystemService for TimeService {}
+
+impl Default for TimeService {
+    fn default() -> Self {
+        TimeService {
+            clients: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ClientA;
+
+impl Actor for ClientA {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("🐰 starting ClientA");
+        TimeService::from_registry()
+            .send(RegisterForTime(ctx.address().downgrade().recipient()))
+            .into_actor(self)
+            .then(|_, _slf, _| fut::ready(()))
+            .spawn(ctx);
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        println!("🐰 stopping ClientA");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        println!("🐰 stopped ClientA");
+    }
+}
+
+impl Handler<TimePing> for ClientA {
+    type Result = ();
+
+    fn handle(&mut self, msg: TimePing, _ctx: &mut Self::Context) -> Self::Result {
+        println!("🐰 ClientA received ping: {:?}", msg);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ClientB;
+
+impl Actor for ClientB {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        println!("🐇 starting ClientB");
+        TimeService::from_registry()
+            .send(RegisterForTime(ctx.address().downgrade().recipient()))
+            .into_actor(self)
+            .then(|_, _slf, _| fut::ready(()))
+            .spawn(ctx);
+    }
+
+    fn stopping(&mut self, _ctx: &mut Self::Context) -> Running {
+        println!("🐇  stopping ClientB");
+        Running::Stop
+    }
+
+    fn stopped(&mut self, _ctx: &mut Self::Context) {
+        println!("🐇 stopped ClientB");
+    }
+}
+
+impl Handler<TimePing> for ClientB {
+    type Result = ();
+
+    fn handle(&mut self, msg: TimePing, _ctx: &mut Self::Context) -> Self::Result {
+        println!("🐇  ClientB received ping: {:?}", msg);
+    }
+}
+
+#[actix_rt::main]
+async fn main() {
+    {
+        println!("🎩 creating client client A");
+        let _client_a = ClientA.start();
+        {
+            println!("🎩 creating client client B");
+            let _client_b = ClientB.start();
+
+            println!("🎩 press Ctrl-C to stop client B");
+            tokio::signal::ctrl_c().await.unwrap();
+            println!("🎩 Ctrl-C received, stopping client");
+        }
+
+        println!("🎩 press Ctrl-C to stop client A");
+        tokio::signal::ctrl_c().await.unwrap();
+        println!("🎩 Ctrl-C received, stopping client");
+    }
+
+    tokio::signal::ctrl_c().await.unwrap();
+    println!("🎩 Ctrl-C received, shutting down");
+    System::current().stop();
+}

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -584,7 +584,6 @@ where
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync> {
         Box::new(self.clone())
     }
-
 }
 
 //

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -45,6 +45,7 @@ where
     ///
     /// Returns [`None`] if the actor has since been dropped.
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>>;
+    fn boxed(&self) -> Box<dyn WeakSender<M> + Sync>;
 }
 
 /// The transmission end of a channel which is used to send values.
@@ -579,6 +580,11 @@ where
             None
         }
     }
+
+    fn boxed(&self) -> Box<dyn WeakSender<M> + Sync> {
+        Box::new(self.clone())
+    }
+
 }
 
 //

--- a/src/address/channel.rs
+++ b/src/address/channel.rs
@@ -41,6 +41,9 @@ where
     M::Result: Send,
     M: Message + Send,
 {
+    /// Attempts to upgrade a `WeakAddressSender<A>` to a [`Sender<M>`]
+    ///
+    /// Returns [`None`] if the actor has since been dropped.
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>>;
 }
 

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -348,6 +348,16 @@ where
     wtx: Box<dyn WeakSender<M> + Sync>,
 }
 
+impl<M> fmt::Debug for WeakRecipient<M>
+where
+    M: Message + Send,
+    M::Result: Send,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(fmt, "WeakRecipient {{ /* omitted */ }}")
+    }
+}
+
 impl<M> WeakRecipient<M>
 where
     M: Message + Send,
@@ -358,7 +368,7 @@ where
     }
 
     /// Attempts to upgrade the `WeakRecipient<M>` pointer to an `Recipient<M>`, similar to `WeakAddr<A>`
-    pub fn upgrade(self) -> Option<Recipient<M>> {
+    pub fn upgrade(&self) -> Option<Recipient<M>> {
         self.wtx.upgrade().map(Recipient::new)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use actix_rt::{Arbiter, System, SystemRunner};
 pub use crate::actor::{
     Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
 };
-pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr};
+pub use crate::address::{Addr, MailboxError, Recipient, WeakAddr, WeakRecipient};
 // pub use crate::arbiter::{Arbiter, ArbiterBuilder};
 pub use crate::context::Context;
 pub use crate::fut::{ActorFuture, ActorStream, FinishStream, WrapFuture, WrapStream};

--- a/tests/test_address.rs
+++ b/tests/test_address.rs
@@ -27,6 +27,7 @@ impl actix::Handler<Ping> for MyActor {
     }
 }
 
+#[derive(Debug)]
 struct MyActor3;
 
 impl Actor for MyActor3 {
@@ -69,9 +70,9 @@ fn test_address() {
     assert_eq!(count.load(Ordering::Relaxed), 4);
 }
 
-struct WeakRunner;
+struct WeakAddressRunner;
 
-impl Actor for WeakRunner {
+impl Actor for WeakAddressRunner {
     type Context = Context<Self>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
@@ -100,7 +101,51 @@ impl Actor for WeakRunner {
 #[test]
 fn test_weak_address() {
     System::run(move || {
-        WeakRunner.start();
+        WeakAddressRunner.start();
+    })
+    .unwrap();
+}
+
+struct WeakRecipientRunner;
+
+impl Actor for WeakRecipientRunner {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        let count0 = Arc::new(AtomicUsize::new(0));
+        let addr1 = MyActor(count0).start();
+        let addr2 = MyActor3.start();
+
+        // let recipient1 = addr1.clone().recipient();
+        let recipient2 = addr2.clone().recipient();
+
+        let weak1 = addr1.downgrade().recipient();
+        let weak2 = addr2.downgrade().recipient();
+        // not strictly necessary, weak1 is dropped by RIAA since nobody in `run_later` uses it.
+        // to make this test red, move drop(addr1) to the line before `System::current().stop()`
+        drop(addr1);
+
+        ctx.run_later(Duration::new(0, 1000), move |_, _| {
+            if weak1.upgrade().is_none() {
+            } else {
+                System::current().stop_with_code(1);
+                panic!("Should not be able to upgrade weak1!");
+            }
+            match weak2.upgrade() {
+                Some(addr) => {
+                    assert!(recipient2 == addr);
+                }
+                None => panic!("Should be able to upgrade weak2!"),
+            }
+            System::current().stop();
+        });
+    }
+}
+
+#[test]
+fn test_weak_recipient() {
+    System::run(move || {
+        WeakRecipientRunner.start();
     })
     .unwrap();
 }

--- a/tests/test_address.rs
+++ b/tests/test_address.rs
@@ -126,8 +126,7 @@ impl Actor for WeakRecipientRunner {
         drop(addr1);
 
         ctx.run_later(Duration::new(0, 1000), move |_, _| {
-            if weak1.upgrade().is_none() {
-            } else {
+            if weak1.upgrade().is_some() {
                 System::current().stop_with_code(1);
                 panic!("Should not be able to upgrade weak1!");
             }


### PR DESCRIPTION
With this change you can now call `.recipient()` on `WeakAddr<A>` just
like on `Addr<A>`. In this case you get a `WeakRecipient<M>` that can
be upgraded to a `Recipient<M>`.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
INSERT_PR_TYPE


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
Hi there,
I'm trying to convert my project to make greater use of `Recipient<M>` instead of `Addr<A>` since I believe it allows to loosen some tight coupling here and there. Unfortunately there is no equivalent to `WeakAddr<A>` for Recipients yet, so I cannot really use Recipients at the moment without running the risk of leaking objects.
Therefore I would like to suggest adding `WeakRecipients` to actix.

This PR supersedes #418, which was flawed. In that attempt I made the `Box` inside the `Recipient` an `Arc` and downgraded it.
you would call
```rust
let weak_rcp = my_actor.addr().recipient().downgrade();
```

That however meant  that you the `WeakRecipient` was invalidated immediately.
In this second attempt I'm creating the `WeakRecipient` from an existing `WeakAddr`. 
```rust
let weak_rcp = my_actor.addr().downgrade().recipient();
```

Thank you very much for your review.