### PR TITLE
enable nested sync arbiters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,10 +9,12 @@
   which is enabled by default but can be switched off to reduce dependencies. [#424]
 * The `where` clause on `Response::fut()` was relaxed to no longer require `T: Unpin`, allowing a
   `Response` to be created with an `async` block [#421]
+* Send `SyncArbiter` to current `System`'s `Arbiter` and run it as future there. Enabling nested `SyncArbiter`s [#439]  
 
 [#421]: https://github.com/actix/actix/pull/421
 [#424]: https://github.com/actix/actix/pull/424
 [#427]: https://github.com/actix/actix/pull/427
+[#439]: https://github.com/actix/actix/pull/439
 
 
 ## 0.10.0 - 2020-09-10

--- a/actix-derive/src/message.rs
+++ b/actix-derive/src/message.rs
@@ -69,10 +69,10 @@ fn get_attribute_type_multiple(
             .map(|m| meta_item_to_ty(m).ok())
             .collect())
     } else {
-        return Err(syn::Error::new_spanned(
+        Err(syn::Error::new_spanned(
             attr,
             format!("The correct syntax is #[{}(type, type, ...)]", name),
-        ));
+        ))
     }
 }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -131,10 +131,10 @@ where
             });
         }
 
-        actix_rt::spawn(Self {
+        System::current().arbiter().send(Box::pin(Self {
             queue: Some(sender),
             msgs: rx,
-        });
+        }));
 
         Addr::new(tx)
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -420,7 +420,7 @@ mod tests {
 
     #[actix_rt::test]
     async fn nested_sync_arbiters() {
-        let addr = SyncArbiter::start(1, || SyncActor1::run());
+        let addr = SyncArbiter::start(1, SyncActor1::run);
         let (tx, rx) = oneshot::channel();
         addr.send(Msg(tx)).await.unwrap();
         assert_eq!(233u8, rx.await.unwrap());


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Not sure if this can be considered a bug but sync arbiter would want to spawn on current thread arbiter.
This means spawn nested sync arbiter would not work and no panic or error is shown.

This PR send the sync arbiter to current system and spawn it there to work around the requirement of current thread arbiter.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #434