### PR TITLE
Remove return value from Recipient::do_send

### DIFF
--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -236,8 +236,9 @@ where
     /// Sends a message.
     ///
     /// Deliver the message even if the recipient's mailbox is full.
-    pub fn do_send(&self, msg: M) -> Result<(), SendError<M>> {
-        self.tx.do_send(msg)
+    /// If the mailbox is closed, the message is silently dropped.
+    pub fn do_send(&self, msg: M) {
+        let _ = self.tx.do_send(msg);
     }
 
     /// Attempts to send a message.


### PR DESCRIPTION
do_send() is supposed to be the fire and forget way of sending, as
opposed to try_send(). This change aligns the signatures of
`Addr::do_send` and `Recipient::do_send()`.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->


<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #440
