### PR TITLE
Implement basic derive macro for 'Actor'

### DIFF
--- a/actix-derive/CHANGES.md
+++ b/actix-derive/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+* Add `Actor` proc derive macro
+
 ## 0.5.0 (2019-10-27
 * Update syn & quote to 1.0
 

--- a/actix-derive/src/actor.rs
+++ b/actix-derive/src/actor.rs
@@ -1,0 +1,42 @@
+use crate::utils::find_attribute_meta;
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::Meta;
+
+pub const ACTOR_ATTR: &str = "actor";
+
+pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let context_type = find_attribute_meta(ast, ACTOR_ATTR)
+        .and_then(get_context_type)
+        .map(|t| t.into_token_stream())
+        .unwrap_or(quote! { ::actix::dev::Context });
+
+    quote! {
+        impl ::actix::Actor for #name {
+            type Context = #context_type<Self>;
+        }
+    }
+}
+
+fn get_context_type(meta: Meta) -> Option<syn::Type> {
+    if let syn::Meta::List(ref list) = meta {
+        if list.nested.is_empty() {
+            return None;
+        }
+
+        get_context_type_from_meta(&list.nested[0])
+    } else {
+        None
+    }
+}
+
+fn get_context_type_from_meta(item: &syn::NestedMeta) -> Option<syn::Type> {
+    match item {
+        syn::NestedMeta::Lit(syn::Lit::Str(ref s)) => {
+            syn::parse_str::<syn::Type>(&s.value()).ok()
+        }
+        _ => None,
+    }
+}

--- a/actix-derive/src/lib.rs
+++ b/actix-derive/src/lib.rs
@@ -5,8 +5,10 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 use syn::DeriveInput;
 
+mod actor;
 mod message;
 mod message_response;
+mod utils;
 
 #[proc_macro_derive(Message, attributes(rtype))]
 pub fn message_derive_rtype(input: TokenStream) -> TokenStream {
@@ -20,4 +22,11 @@ pub fn message_response_derive_rtype(input: TokenStream) -> TokenStream {
     let ast: DeriveInput = syn::parse(input).unwrap();
 
     message_response::expand(&ast).into()
+}
+
+#[proc_macro_derive(Actor, attributes(actor))]
+pub fn actor_derive(input: TokenStream) -> TokenStream {
+    let ast: DeriveInput = syn::parse(input).unwrap();
+
+    actor::expand(&ast).into()
 }

--- a/actix-derive/src/message.rs
+++ b/actix-derive/src/message.rs
@@ -1,6 +1,8 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 
+use crate::utils::find_attribute_meta;
+
 pub const MESSAGE_ATTR: &str = "rtype";
 
 pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
@@ -42,25 +44,9 @@ fn get_attribute_type_multiple(
     ast: &syn::DeriveInput,
     name: &str,
 ) -> syn::Result<Vec<Option<syn::Type>>> {
-    let attr = ast
-        .attrs
-        .iter()
-        .find_map(|a| {
-            let a = a.parse_meta();
-            match a {
-                Ok(meta) => {
-                    if meta.path().is_ident(name) {
-                        Some(meta)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            }
-        })
-        .ok_or_else(|| {
-            syn::Error::new(Span::call_site(), format!("Expect a attribute `{}`", name))
-        })?;
+    let attr = find_attribute_meta(ast, name).ok_or_else(|| {
+        syn::Error::new(Span::call_site(), format!("Expect a attribute `{}`", name))
+    })?;
 
     if let syn::Meta::List(ref list) = attr {
         Ok(list

--- a/actix-derive/src/utils.rs
+++ b/actix-derive/src/utils.rs
@@ -1,0 +1,15 @@
+use syn::Meta;
+
+/// Finds an attribute matching an identifier
+pub fn find_attribute_meta(ast: &syn::DeriveInput, attribute: &str) -> Option<Meta> {
+    ast.attrs.iter().find_map(|attr| {
+        let maybe_meta = attr.parse_meta().ok();
+        maybe_meta.and_then(|meta| {
+            if meta.path().is_ident(attribute) {
+                Some(meta)
+            } else {
+                None
+            }
+        })
+    })
+}

--- a/actix-derive/tests/test_actor_derive_with_custom_context.rs
+++ b/actix-derive/tests/test_actor_derive_with_custom_context.rs
@@ -1,5 +1,5 @@
 use actix::{Actor, Handler, System};
-use actix_derive::{Actor, Message, MessageResponse};
+use actix_derive::{Message, MessageResponse};
 
 #[derive(MessageResponse)]
 struct Added(usize);
@@ -8,7 +8,7 @@ struct Added(usize);
 #[rtype(result = "Added")]
 struct Sum(usize, usize);
 
-#[derive(Actor, Default)]
+#[derive(actix_derive::Actor, Default)]
 #[actor(context = "::actix::SyncContext")]
 struct Adder;
 

--- a/actix-derive/tests/test_actor_derive_with_custom_context.rs
+++ b/actix-derive/tests/test_actor_derive_with_custom_context.rs
@@ -9,6 +9,7 @@ struct Added(usize);
 struct Sum(usize, usize);
 
 #[derive(Actor, Default)]
+#[actor(context = "::actix::SyncContext")]
 struct Adder;
 
 impl Handler<Sum> for Adder {

--- a/actix-derive/tests/test_macro.rs
+++ b/actix-derive/tests/test_macro.rs
@@ -1,5 +1,5 @@
 use actix::{Actor, Handler, System};
-use actix_derive::{Actor, Message, MessageResponse};
+use actix_derive::{Message, MessageResponse};
 
 #[derive(MessageResponse)]
 struct Added(usize);
@@ -8,7 +8,7 @@ struct Added(usize);
 #[rtype(result = "Added")]
 struct Sum(usize, usize);
 
-#[derive(Actor, Default)]
+#[derive(actix_derive::Actor, Default)]
 struct Adder;
 
 impl Handler<Sum> for Adder {


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature / Refactor

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

* Implements basic derive macro for 'Actor'
* Refactors 'message' derive utility so it can be shared

Syntax:

```rust
#[derive(Actor)]
struct Adder;
```

Generates:
```rust
impl ::actix::Actor for Adder {
    type Context = ::actix::Context<Self>;
}
```

Furthermore:
```rust
#[derive(Actor)]
#[actor(context = "::actix::SyncContext")]
struct Adder;
```

Generates:
```rust
impl ::actix::Actor for Adder {
    type Context = ::actix::SyncContext<Self>;
}
```

Never wrote a macro (or much rust) so I'm sure there are cases that this does not cover.

Can update the README if it's ok.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->