### PR TITLE
remove unsafe on envelopes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 * Allow creating `WeakRecipient` from `WeakAddr`, similiar to `Recipient` from `Addr`. [#432]
 * Send `SyncArbiter` to current `System`'s `Arbiter` and run it as future there. Enabling nested `SyncArbiter`s [#439] 
 * Use generic type instead of associate type for `EnvelopeProxy`. `SyncEnvelopeProxy` and `SyncContextEnvelope` are no 
-  longer bound to Actor. #[445] 
+  longer bound to Actor. [#445] 
 
 [#421]: https://github.com/actix/actix/pull/421
 [#424]: https://github.com/actix/actix/pull/424

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,9 @@
   `Response` to be created with an `async` block [#421]
 * Update `pin-project` to 1.0. [#435]
 * Allow creating `WeakRecipient` from `WeakAddr`, similiar to `Recipient` from `Addr`. [#432]
-* Send `SyncArbiter` to current `System`'s `Arbiter` and run it as future there. Enabling nested `SyncArbiter`s [#439]  
+* Send `SyncArbiter` to current `System`'s `Arbiter` and run it as future there. Enabling nested `SyncArbiter`s [#439] 
+* Use generic type instead of associate type for `EnvelopeProxy`. `SyncEnvelopeProxy` and `SyncContextEnvelope` are no 
+  longer bound to Actor. #[445] 
 
 [#421]: https://github.com/actix/actix/pull/421
 [#424]: https://github.com/actix/actix/pull/424
@@ -19,6 +21,7 @@
 [#432]: https://github.com/actix/actix/pull/432
 [#435]: https://github.com/actix/actix/pull/435
 [#439]: https://github.com/actix/actix/pull/439
+[#445]: https://github.com/actix/actix/pull/445
 
 
 ## 0.10.0 - 2020-09-10


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Use generic type instead of associate type for `EnvelopeProxy`. As a result `SyncEnvelopeProxy` and `SyncContextEnvelope` are no longer bound to `Actor` type make them `Send` and no unsafe impl for it are needed.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
