### PR TITLE
Bump crossbeam-channel from 0.4.x to 0.5.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 * Use generic type instead of associate type for `EnvelopeProxy`. `SyncEnvelopeProxy` and `SyncContextEnvelope` are no 
   longer bound to Actor. [#445]
 * Re-export `actix_rt::main` macro as `actix::main` [#448]
+* Bump `crossbeam-channel` to `0.5`
 
 [#421]: https://github.com/actix/actix/pull/421
 [#424]: https://github.com/actix/actix/pull/424

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ actix_derive = { version = "0.5", optional = true }
 actix-macros = { version = "0.1.3", features = ["actix-reexport"] }
 
 bytes = "0.5.3"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 derive_more = "0.99.2"
 futures-channel = { version = "0.3.1", default-features = false }
 futures-util = { version = "0.3.1", default-features = false, features = ["sink"] }


### PR DESCRIPTION
## PR Type
Dependency bump

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
There are no breaking changes in the `crossbeam-channel` 0.5.0 changelog, so there are no required changes on `actix`'s side.