### PR TITLE
rework ActorFuture trait

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,11 @@
 # CHANGES
 
 ## Unreleased - 2021-xx-xx
+### Changed
+* Rework `ActorFuture` trait. [#465]
+* `actix::fut::{wrap_future, wrap_stream}` would need type annotation for Actor type. [#465]
+  
+[#465]: https://github.com/actix/actix/issues/465
 
 
 ## 0.11.0-beta.2 - 2021-02-06

--- a/actix/Cargo.toml
+++ b/actix/Cargo.toml
@@ -39,6 +39,7 @@ crossbeam-channel = "0.5"
 futures-core = { version = "0.3.7", default-features = false }
 futures-sink = { version = "0.3.7", default-features = false }
 futures-task = { version = "0.3.7", default-features = false }
+futures-util = { version = "0.3.7", default-features = false }
 log = "0.4"
 once_cell = "1.5"
 parking_lot = "0.11"

--- a/actix/src/actor.rs
+++ b/actix/src/actor.rs
@@ -282,7 +282,7 @@ where
     /// during the actor's stopping stage.
     fn spawn<F>(&mut self, fut: F) -> SpawnHandle
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static;
+        F: ActorFuture<A, Output = ()> + 'static;
 
     /// Spawns a future into the context, waiting for it to resolve.
     ///
@@ -290,7 +290,7 @@ where
     /// resolves.
     fn wait<F>(&mut self, fut: F)
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static;
+        F: ActorFuture<A, Output = ()> + 'static;
 
     /// Checks if the context is paused (waiting for future completion or stopping).
     fn waiting(&self) -> bool;

--- a/actix/src/actors/resolver.rs
+++ b/actix/src/actors/resolver.rs
@@ -328,9 +328,9 @@ impl ResolveFut {
     }
 }
 
-impl ActorFuture for ResolveFut {
+impl ActorFuture<Resolver> for ResolveFut {
     type Output = Result<VecDeque<SocketAddr>, ResolverError>;
-    type Actor = Resolver;
+
     fn poll(
         mut self: Pin<&mut Self>,
         _: &mut Resolver,
@@ -392,9 +392,8 @@ impl TcpConnector {
     }
 }
 
-impl ActorFuture for TcpConnector {
+impl ActorFuture<Resolver> for TcpConnector {
     type Output = Result<TcpStream, ResolverError>;
-    type Actor = Resolver;
 
     fn poll(
         self: Pin<&mut Self>,

--- a/actix/src/context.rs
+++ b/actix/src/context.rs
@@ -49,7 +49,7 @@ where
     #[inline]
     fn spawn<F>(&mut self, fut: F) -> SpawnHandle
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static,
+        F: ActorFuture<A, Output = ()> + 'static,
     {
         self.parts.spawn(fut)
     }
@@ -57,7 +57,7 @@ where
     #[inline]
     fn wait<F>(&mut self, fut: F)
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static,
+        F: ActorFuture<A, Output = ()> + 'static,
     {
         self.parts.wait(fut)
     }
@@ -183,7 +183,7 @@ impl<A, T> ContextFutureSpawner<A> for T
 where
     A: Actor,
     A::Context: AsyncContext<A>,
-    T: ActorFuture<Output = (), Actor = A> + 'static,
+    T: ActorFuture<A, Output = ()> + 'static,
 {
     #[inline]
     fn spawn(self, ctx: &mut A::Context) {

--- a/actix/src/contextimpl.rs
+++ b/actix/src/contextimpl.rs
@@ -25,10 +25,7 @@ bitflags! {
     }
 }
 
-type Item<A> = (
-    SpawnHandle,
-    Pin<Box<dyn ActorFuture<Output = (), Actor = A>>>,
-);
+type Item<A> = (SpawnHandle, Pin<Box<dyn ActorFuture<A, Output = ()>>>);
 
 pub trait AsyncContextParts<A>: ActorContext + AsyncContext<A>
 where
@@ -129,11 +126,11 @@ where
     /// Spawn new future to this context.
     pub fn spawn<F>(&mut self, fut: F) -> SpawnHandle
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static,
+        F: ActorFuture<A, Output = ()> + 'static,
     {
         let handle = self.handles[0].next();
         self.handles[0] = handle;
-        let fut: Box<dyn ActorFuture<Output = (), Actor = A>> = Box::new(fut);
+        let fut: Box<dyn ActorFuture<A, Output = ()>> = Box::new(fut);
         self.items.push((handle, Pin::from(fut)));
         handle
     }
@@ -144,7 +141,7 @@ where
     /// During wait period actor does not receive any messages.
     pub fn wait<F>(&mut self, f: F)
     where
-        F: ActorFuture<Output = (), Actor = A> + 'static,
+        F: ActorFuture<A, Output = ()> + 'static,
     {
         self.wait.push(ActorWaitItem::new(f));
     }

--- a/actix/src/fut/either.rs
+++ b/actix/src/fut/either.rs
@@ -71,18 +71,18 @@ impl<T> Either<T, T> {
     }
 }
 
-impl<A, B> ActorFuture for Either<A, B>
+impl<A, Act, B> ActorFuture<Act> for Either<A, B>
 where
-    A: ActorFuture,
-    B: ActorFuture<Output = A::Output, Actor = A::Actor>,
+    Act: Actor,
+    A: ActorFuture<Act>,
+    B: ActorFuture<Act, Output = A::Output>,
 {
     type Output = A::Output;
-    type Actor = A::Actor;
 
     fn poll(
         self: Pin<&mut Self>,
-        act: &mut A::Actor,
-        ctx: &mut <A::Actor as Actor>::Context,
+        act: &mut Act,
+        ctx: &mut Act::Context,
         task: &mut Context<'_>,
     ) -> Poll<A::Output> {
         match self.project() {

--- a/actix/src/fut/ready_fut.rs
+++ b/actix/src/fut/ready_fut.rs
@@ -1,5 +1,5 @@
 //! Definition of the `Result` (immediately finished) combinator
-use std::marker::PhantomData;
+use std::future::Future;
 use std::pin::Pin;
 use std::task;
 use std::task::Poll;
@@ -7,38 +7,21 @@ use std::task::Poll;
 use crate::actor::Actor;
 use crate::fut::ActorFuture;
 
-/// Future for the [`ready`](ready()) function.
-#[derive(Debug)]
-#[must_use = "futures do nothing unless polled"]
-pub struct Ready<T, A> {
-    inner: Option<T>,
-    act: PhantomData<A>,
-}
+pub use futures_util::future::{ready, Ready};
 
-impl<T, A> Unpin for Ready<T, A> {}
-
-/// Create a future that is immediately ready with a value.
-pub fn ready<T, A>(r: T) -> Ready<T, A> {
-    Ready {
-        inner: Some(r),
-        act: PhantomData,
-    }
-}
-
-impl<T, A> ActorFuture for Ready<T, A>
+impl<T, A> ActorFuture<A> for Ready<T>
 where
     A: Actor,
 {
     type Output = T;
-    type Actor = A;
 
     #[inline]
     fn poll(
-        mut self: Pin<&mut Self>,
-        _: &mut Self::Actor,
-        _: &mut <Self::Actor as Actor>::Context,
-        _: &mut task::Context<'_>,
+        self: Pin<&mut Self>,
+        _: &mut A,
+        _: &mut A::Context,
+        cx: &mut task::Context<'_>,
     ) -> Poll<Self::Output> {
-        Poll::Ready(self.inner.take().expect("cannot poll Result twice"))
+        Future::poll(self, cx)
     }
 }

--- a/actix/src/fut/result.rs
+++ b/actix/src/fut/result.rs
@@ -1,24 +1,14 @@
 //! Definition of the `Result` (immediately finished) combinator
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task;
-use std::task::Poll;
 
-use crate::actor::Actor;
-use crate::fut::ActorFuture;
+use super::ready_fut::{ready, Ready};
 
 /// A future representing a value that is immediately ready.
 ///
 /// Created by the `result` function.
-#[derive(Debug)]
 #[must_use = "futures do nothing unless polled"]
 // TODO: rename this to `Result` on the next major version
-pub struct FutureResult<T, E, A> {
-    inner: Option<Result<T, E>>,
-    act: PhantomData<A>,
-}
-
-impl<T, E, A> Unpin for FutureResult<T, E, A> {}
+// TODO: use std::future::Ready when MSRV surpass 1.48
+pub type FutureResult<T, E> = Ready<Result<T, E>>;
 
 /// Creates a new "leaf future" which will resolve with the given result.
 ///
@@ -36,14 +26,11 @@ impl<T, E, A> Unpin for FutureResult<T, E, A> {}
 ///     type Context = Context<Self>;
 /// }
 ///
-/// let future_of_1 = fut::result::<u32, u32, MyActor>(Ok(1));
-/// let future_of_err_2 = fut::result::<u32, u32, MyActor>(Err(2));
+/// let future_of_1 = fut::result::<u32, u32>(Ok(1));
+/// let future_of_err_2 = fut::result::<u32, u32>(Err(2));
 /// ```
-pub fn result<T, E, A>(r: Result<T, E>) -> FutureResult<T, E, A> {
-    FutureResult {
-        inner: Some(r),
-        act: PhantomData,
-    }
+pub fn result<T, E>(r: Result<T, E>) -> FutureResult<T, E> {
+    ready(r)
 }
 
 /// Creates a "leaf future" from an immediate value of a finished and
@@ -63,10 +50,10 @@ pub fn result<T, E, A>(r: Result<T, E>) -> FutureResult<T, E, A> {
 ///     type Context = Context<Self>;
 /// }
 ///
-/// let future_of_1 = ok::<u32, u32, MyActor>(1);
+/// let future_of_1 = ok::<u32, u32>(1);
 /// ```
-pub fn ok<T, E, S>(t: T) -> FutureResult<T, E, S> {
-    result(Ok(t))
+pub fn ok<T, E>(t: T) -> FutureResult<T, E> {
+    ready(Ok(t))
 }
 
 /// Creates a "leaf future" from an immediate value of a failed computation.
@@ -84,36 +71,8 @@ pub fn ok<T, E, S>(t: T) -> FutureResult<T, E, S> {
 ///     type Context = Context<Self>;
 /// }
 ///
-/// let future_of_err_1 = fut::err::<u32, u32, MyActor>(1);
+/// let future_of_err_1 = fut::err::<u32, u32>(1);
 /// ```
-pub fn err<T, E, A>(e: E) -> FutureResult<T, E, A> {
-    result(Err(e))
-}
-
-impl<T, E, A> ActorFuture for FutureResult<T, E, A>
-where
-    A: Actor,
-{
-    type Output = Result<T, E>;
-    type Actor = A;
-
-    fn poll(
-        self: Pin<&mut Self>,
-        _: &mut Self::Actor,
-        _: &mut <Self::Actor as Actor>::Context,
-        _: &mut task::Context<'_>,
-    ) -> Poll<Self::Output> {
-        Poll::Ready(
-            self.get_mut()
-                .inner
-                .take()
-                .expect("cannot poll Result twice"),
-        )
-    }
-}
-
-impl<T, E, A> From<Result<T, E>> for FutureResult<T, E, A> {
-    fn from(r: Result<T, E>) -> Self {
-        result(r)
-    }
+pub fn err<T, E>(e: E) -> FutureResult<T, E> {
+    ready(Err(e))
 }

--- a/actix/src/fut/stream_finish.rs
+++ b/actix/src/fut/stream_finish.rs
@@ -13,24 +13,27 @@ pin_project! {
     /// This structure is produced by the `ActorStream::finish` method.
     #[must_use = "streams do nothing unless polled"]
     #[derive(Debug)]
-    pub struct StreamFinish<S: ActorStream> {
+    pub struct StreamFinish<S> {
         #[pin]
         stream: S
     }
 }
 
-pub fn new<S: ActorStream>(stream: S) -> StreamFinish<S> {
+pub fn new<S>(stream: S) -> StreamFinish<S> {
     StreamFinish { stream }
 }
 
-impl<S: ActorStream> ActorFuture for StreamFinish<S> {
+impl<S, A> ActorFuture<A> for StreamFinish<S>
+where
+    S: ActorStream<A>,
+    A: Actor,
+{
     type Output = ();
-    type Actor = S::Actor;
 
     fn poll(
         mut self: Pin<&mut Self>,
-        act: &mut S::Actor,
-        ctx: &mut <S::Actor as Actor>::Context,
+        act: &mut A,
+        ctx: &mut A::Context,
         task: &mut Context<'_>,
     ) -> Poll<()> {
         loop {

--- a/actix/src/fut/stream_map.rs
+++ b/actix/src/fut/stream_map.rs
@@ -20,26 +20,27 @@ pin_project! {
     }
 }
 
-pub fn new<S, F, U>(stream: S, f: F) -> StreamMap<S, F>
+pub fn new<S, A, F, U>(stream: S, f: F) -> StreamMap<S, F>
 where
-    F: FnMut(S::Item, &mut S::Actor, &mut <S::Actor as Actor>::Context) -> U,
-    S: ActorStream,
+    F: FnMut(S::Item, &mut A, &mut A::Context) -> U,
+    S: ActorStream<A>,
+    A: Actor,
 {
     StreamMap { stream, f }
 }
 
-impl<S, F, U> ActorStream for StreamMap<S, F>
+impl<S, A, F, U> ActorStream<A> for StreamMap<S, F>
 where
-    S: ActorStream,
-    F: FnMut(S::Item, &mut S::Actor, &mut <S::Actor as Actor>::Context) -> U,
+    S: ActorStream<A>,
+    A: Actor,
+    F: FnMut(S::Item, &mut A, &mut A::Context) -> U,
 {
     type Item = U;
-    type Actor = S::Actor;
 
     fn poll_next(
         self: Pin<&mut Self>,
-        act: &mut Self::Actor,
-        ctx: &mut <S::Actor as Actor>::Context,
+        act: &mut A,
+        ctx: &mut A::Context,
         task: &mut Context<'_>,
     ) -> Poll<Option<U>> {
         let this = self.project();

--- a/actix/src/fut/stream_then.rs
+++ b/actix/src/fut/stream_then.rs
@@ -13,24 +13,21 @@ pin_project! {
     /// This structure is produced by the `ActorStream::then` method.
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
-    pub struct StreamThen<S, F: 'static, U>
-    where
-        U: IntoActorFuture,
-        S: ActorStream,
-    {
+    pub struct StreamThen<S, Fn, F> {
         #[pin]
         stream: S,
         #[pin]
-        future: Option<U::Future>,
-        f: F,
+        future: Option<F>,
+        f: Fn,
     }
 }
 
-pub fn new<S, F: 'static, U>(stream: S, f: F) -> StreamThen<S, F, U>
+pub fn new<S, A, Fn, F>(stream: S, f: Fn) -> StreamThen<S, Fn, F::Future>
 where
-    S: ActorStream,
-    F: FnMut(S::Item, &mut S::Actor, &mut <S::Actor as Actor>::Context) -> U,
-    U: IntoActorFuture<Actor = S::Actor>,
+    S: ActorStream<A>,
+    A: Actor,
+    F: IntoActorFuture<A>,
+    Fn: FnMut(S::Item, &mut A, &mut A::Context) -> F,
 {
     StreamThen {
         stream,
@@ -39,21 +36,21 @@ where
     }
 }
 
-impl<S, F: 'static, U> ActorStream for StreamThen<S, F, U>
+impl<S, A, Fn, F> ActorStream<A> for StreamThen<S, Fn, F::Future>
 where
-    S: ActorStream,
-    F: FnMut(S::Item, &mut S::Actor, &mut <S::Actor as Actor>::Context) -> U,
-    U: IntoActorFuture<Actor = S::Actor>,
+    S: ActorStream<A>,
+    A: Actor,
+    F: IntoActorFuture<A>,
+    Fn: FnMut(S::Item, &mut A, &mut A::Context) -> F,
 {
-    type Item = U::Output;
-    type Actor = S::Actor;
+    type Item = F::Output;
 
     fn poll_next(
         mut self: Pin<&mut Self>,
-        act: &mut S::Actor,
-        ctx: &mut <S::Actor as Actor>::Context,
+        act: &mut A,
+        ctx: &mut A::Context,
         task: &mut Context<'_>,
-    ) -> Poll<Option<U::Output>> {
+    ) -> Poll<Option<Self::Item>> {
         loop {
             let this = self.as_mut().project();
             match this.future.as_pin_mut() {

--- a/actix/src/fut/stream_timeout.rs
+++ b/actix/src/fut/stream_timeout.rs
@@ -16,10 +16,7 @@ pin_project! {
     /// This is created by the `ActorFuture::timeout()` method.
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
-    pub struct StreamTimeout<S>
-    where
-        S: ActorStream,
-    {
+    pub struct StreamTimeout<S> {
         #[pin]
         stream: S,
         dur: Duration,
@@ -28,9 +25,10 @@ pin_project! {
     }
 }
 
-pub fn new<S>(stream: S, timeout: Duration) -> StreamTimeout<S>
+pub fn new<S, A>(stream: S, timeout: Duration) -> StreamTimeout<S>
 where
-    S: ActorStream,
+    S: ActorStream<A>,
+    A: Actor,
 {
     StreamTimeout {
         stream,
@@ -39,17 +37,17 @@ where
     }
 }
 
-impl<S> ActorStream for StreamTimeout<S>
+impl<S, A> ActorStream<A> for StreamTimeout<S>
 where
-    S: ActorStream,
+    S: ActorStream<A>,
+    A: Actor,
 {
     type Item = Result<S::Item, ()>;
-    type Actor = S::Actor;
 
     fn poll_next(
         self: Pin<&mut Self>,
-        act: &mut S::Actor,
-        ctx: &mut <S::Actor as Actor>::Context,
+        act: &mut A,
+        ctx: &mut A::Context,
         task: &mut Context<'_>,
     ) -> Poll<Option<Result<S::Item, ()>>> {
         let mut this = self.project();

--- a/actix/src/fut/timeout.rs
+++ b/actix/src/fut/timeout.rs
@@ -16,10 +16,7 @@ pin_project! {
     /// This is created by the `ActorFuture::timeout()` method.
     #[derive(Debug)]
     #[must_use = "futures do nothing unless polled"]
-    pub struct Timeout<F>
-    where
-        F: ActorFuture,
-    {
+    pub struct Timeout<F>{
         #[pin]
         fut: F,
         #[pin]
@@ -27,27 +24,24 @@ pin_project! {
     }
 }
 
-pub fn new<F>(future: F, timeout: Duration) -> Timeout<F>
-where
-    F: ActorFuture,
-{
+pub fn new<F>(future: F, timeout: Duration) -> Timeout<F> {
     Timeout {
         fut: future,
         timeout: sleep(timeout),
     }
 }
 
-impl<F> ActorFuture for Timeout<F>
+impl<F, A> ActorFuture<A> for Timeout<F>
 where
-    F: ActorFuture,
+    F: ActorFuture<A>,
+    A: Actor,
 {
     type Output = Result<F::Output, ()>;
-    type Actor = F::Actor;
 
     fn poll(
         self: Pin<&mut Self>,
-        act: &mut F::Actor,
-        ctx: &mut <F::Actor as Actor>::Context,
+        act: &mut A,
+        ctx: &mut A::Context,
         task: &mut Context<'_>,
     ) -> Poll<Self::Output> {
         let this = self.project();

--- a/actix/src/handler.rs
+++ b/actix/src/handler.rs
@@ -205,7 +205,7 @@ where
 ///     }
 /// }
 /// ```
-pub type ResponseActFuture<A, I> = Pin<Box<dyn ActorFuture<Output = I, Actor = A>>>;
+pub type ResponseActFuture<A, I> = Pin<Box<dyn ActorFuture<A, Output = I>>>;
 
 /// A specialized future for asynchronous message handling.
 ///
@@ -507,7 +507,7 @@ where
 
 enum ActorResponseTypeItem<A, I> {
     Result(I),
-    Fut(Pin<Box<dyn ActorFuture<Output = I, Actor = A>>>),
+    Fut(Pin<Box<dyn ActorFuture<A, Output = I>>>),
 }
 
 /// A helper type for representing different types of message responses.
@@ -537,7 +537,7 @@ impl<A: Actor, I> ActorResponse<A, I> {
     /// Creates an asynchronous response.
     pub fn r#async<T>(fut: T) -> Self
     where
-        T: ActorFuture<Output = I, Actor = A> + 'static,
+        T: ActorFuture<A, Output = I> + 'static,
     {
         Self {
             item: ActorResponseTypeItem::Fut(Box::pin(fut)),

--- a/actix/src/stream.rs
+++ b/actix/src/stream.rs
@@ -1,4 +1,3 @@
-use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -93,32 +92,29 @@ where
 }
 
 pin_project! {
-    pub(crate) struct ActorStream<A, S> {
+    pub(crate) struct ActorStream<S> {
         #[pin]
         stream: S,
         started: bool,
-        act: PhantomData<A>,
     }
 }
 
-impl<A, S> ActorStream<A, S> {
+impl<S> ActorStream<S> {
     pub fn new(fut: S) -> Self {
         Self {
             stream: fut,
             started: false,
-            act: PhantomData,
         }
     }
 }
 
-impl<A, S> ActorFuture for ActorStream<A, S>
+impl<A, S> ActorFuture<A> for ActorStream<S>
 where
     S: Stream,
     A: Actor + StreamHandler<S::Item>,
     A::Context: AsyncContext<A>,
 {
     type Output = ();
-    type Actor = A;
 
     fn poll(
         self: Pin<&mut Self>,


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Rework `ActorFuture` trait. 

Move Actor type bind to trait so the type impl `ActorFuture` is not constriant to Actor type.
This enables foreign types impl `ActorFuture` without a new type. (See `actix::fut::result` and `actix::fut::ready_fut`).
And more foreign types can be introduced to further reduce new type wrappers.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
