### PR TITLE
Re-export actix_rt::ArbiterHandle

### DIFF
--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -53,7 +53,7 @@ pub mod utils;
 
 #[cfg(feature = "macros")]
 pub use actix_derive::{main, test, Message, MessageResponse};
-pub use actix_rt::{spawn, Arbiter, System, SystemRunner};
+pub use actix_rt::{spawn, Arbiter, ArbiterHandle, System, SystemRunner};
 
 pub use crate::actor::{
     Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
@@ -88,7 +88,7 @@ pub mod prelude {
     #[cfg(feature = "macros")]
     pub use actix_derive::{Message, MessageResponse};
 
-    pub use actix_rt::{Arbiter, System, SystemRunner};
+    pub use actix_rt::{Arbiter, ArbiterHandle, System, SystemRunner};
 
     pub use crate::actor::{
         Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist

- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

This re-exports `actix_rt::ArbiterHandle` since `Arbiter::current()` and `Arbiter::handle(&self)` now return this type, and `Actor::start_in_arbiter` expects this type as its first argument, so sometimes it is useful to be able to name the type, and currently you have to add `actix-rt` as an explicit dependency.