### PR TITLE
remove waste poll of mailbox

### DIFF
--- a/actix/src/mailbox.rs
+++ b/actix/src/mailbox.rs
@@ -8,10 +8,6 @@ use crate::actor::{Actor, AsyncContext};
 use crate::address::EnvelopeProxy;
 use crate::address::{channel, Addr, AddressReceiver, AddressSenderProducer};
 
-#[cfg(feature = "mailbox_assert")]
-/// Maximum number of consecutive polls in a loop
-const MAX_SYNC_POLLS: u16 = 256;
-
 /// Default address channel capacity
 pub const DEFAULT_CAPACITY: usize = 16;
 
@@ -82,32 +78,18 @@ where
         #[cfg(feature = "mailbox_assert")]
         let mut n_polls = 0u16;
 
-        loop {
-            let mut not_ready = true;
-
-            // sync messages
-            loop {
-                if ctx.waiting() {
-                    return;
-                }
-
-                match Pin::new(&mut self.msgs).poll_next(task) {
-                    Poll::Ready(Some(mut msg)) => {
-                        not_ready = false;
-                        msg.handle(act, ctx);
+        while !ctx.waiting() {
+            match Pin::new(&mut self.msgs).poll_next(task) {
+                Poll::Ready(Some(mut msg)) => {
+                    msg.handle(act, ctx);
+                    #[cfg(feature = "mailbox_assert")]
+                    {
+                        n_polls += 1;
+                        /// Maximum number of consecutive polls in a loop is 256.
+                        assert!(n_polls < 256u16, "Too many messages are being processed. Use Self::Context::notify() instead of direct use of address");
                     }
-                    Poll::Ready(None) | Poll::Pending => break,
                 }
-
-                #[cfg(feature = "mailbox_assert")]
-                {
-                    n_polls += 1;
-                    assert!(n_polls < MAX_SYNC_POLLS, "Too many messages are being processed. Use Self::Context::notify() instead of direct use of address");
-                }
-            }
-
-            if not_ready {
-                return;
+                Poll::Ready(None) | Poll::Pending => return,
             }
         }
     }

--- a/actix/src/mailbox.rs
+++ b/actix/src/mailbox.rs
@@ -85,7 +85,7 @@ where
                     #[cfg(feature = "mailbox_assert")]
                     {
                         n_polls += 1;
-                        /// Maximum number of consecutive polls in a loop is 256.
+                        // Maximum number of consecutive polls in a loop is 256.
                         assert!(n_polls < 256u16, "Too many messages are being processed. Use Self::Context::notify() instead of direct use of address");
                     }
                 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
`Mailbox::poll` was actively polling another round on Pending in some cases.
This result in some waste atomic operations.

This PR would exit poll method directly on Pending.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
