### PR TITLE
remove ResponseChannel trait

### DIFF
--- a/actix-derive/src/message_response.rs
+++ b/actix-derive/src/message_response.rs
@@ -16,9 +16,9 @@ pub fn expand(ast: &syn::DeriveInput) -> TokenStream {
 
     quote! {
         impl #impl_generics ::actix::dev::MessageResponse<_A, _M> for #name #ty_generics #where_clause {
-            fn handle<R: actix::dev::ResponseChannel<_M>>(self, _: &mut _A::Context, tx: Option<R>) {
+            fn handle(self, _: &mut _A::Context, tx: Option<::actix::dev::OneshotSender<Self>>) {
                 if let Some(tx) = tx {
-                    tx.send(self);
+                    let _ = tx.send(self);
                 }
             }
         }

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,10 @@
 # CHANGES
 
 ## Unreleased - 2021-xx-xx
+* Remove `dev::ResponseChannel` trait [#472]
+* `dev::MessageResponse::handle` method does not need generic type [#472]
+
+[#472]: https://github.com/actix/actix/pull/472
 
 
 ## 0.11.0-beta.2 - 2021-02-06

--- a/actix/src/contextitems.rs
+++ b/actix/src/contextitems.rs
@@ -91,7 +91,7 @@ where
         let this = self.project();
         ready!(this.timeout.poll(task));
         let fut = A::handle(act, this.msg.take().unwrap(), ctx);
-        fut.handle::<()>(ctx, None);
+        fut.handle(ctx, None);
         Poll::Ready(())
     }
 }
@@ -137,7 +137,7 @@ where
     ) -> Poll<Self::Output> {
         let this = self.get_mut();
         let fut = Handler::handle(act, this.msg.take().unwrap(), ctx);
-        fut.handle::<()>(ctx, None);
+        fut.handle(ctx, None);
         Poll::Ready(())
     }
 }
@@ -186,7 +186,7 @@ where
             match this.stream.as_mut().poll_next(task) {
                 Poll::Ready(Some(msg)) => {
                     let fut = Handler::handle(act, msg, ctx);
-                    fut.handle::<()>(ctx, None);
+                    fut.handle(ctx, None);
                     if ctx.waiting() {
                         return Poll::Pending;
                     }

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -136,7 +136,7 @@ pub mod dev {
         pub use crate::address::channel::{channel, AddressReceiver, AddressSender};
     }
     pub use crate::contextimpl::{AsyncContextParts, ContextFut, ContextParts};
-    pub use crate::handler::{MessageResponse, ResponseChannel};
+    pub use crate::handler::{MessageResponse, OneshotSender};
     pub use crate::mailbox::Mailbox;
     pub use crate::registry::{Registry, SystemRegistry};
 }


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Remove `ResponseChannel` trait. 
It does not generic over channel type and impl only for `()` and `tokio::sync::oneshot::Sender`.
This would reduce the one generic type from `MessageResponse` trait

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
