### PR TITLE
fix test_weak_address/test_stream_timeout

### DIFF
--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -102,9 +102,13 @@ impl Actor for WeakAddressRunner {
 
 #[test]
 fn test_weak_address() {
-    System::new().block_on(async move {
+    let sys = System::new();
+
+    sys.block_on(async move {
         WeakAddressRunner.start();
     });
+
+    sys.run().unwrap();
 }
 
 struct WeakRecipientRunner;

--- a/actix/tests/test_fut.rs
+++ b/actix/tests/test_fut.rs
@@ -54,15 +54,15 @@ impl Actor for MyStreamActor {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         let mut s = futures_util::stream::FuturesOrdered::new();
-        s.push(sleep(Duration::new(0, 5_000_000)));
-        s.push(sleep(Duration::new(0, 5_000_000)));
+        s.push(sleep(Duration::from_millis(20)));
+        s.push(sleep(Duration::from_millis(20)));
 
         s.into_actor(self)
-            .timeout(Duration::new(0, 1000))
+            .timeout(Duration::from_millis(1))
             .then(|res, act, _| {
                 // Additional waiting time to test `then` call as well
                 async move {
-                    sleep(Duration::from_millis(500)).await;
+                    sleep(Duration::from_millis(20)).await;
                     res
                 }
                 .into_actor(act)

--- a/actix/tests/test_fut.rs
+++ b/actix/tests/test_fut.rs
@@ -67,11 +67,13 @@ impl Actor for MyStreamActor {
                 }
                 .into_actor(act)
             })
-            .map(|e, act, _| {
-                if let Err(()) = e {
-                    act.timeout.store(true, Ordering::Relaxed);
-                    System::current().stop();
-                }
+            .map(|res, act, _| {
+                assert!(
+                    res.is_err(),
+                    "MyStreamActor should return error when timed out"
+                );
+                act.timeout.store(true, Ordering::Relaxed);
+                System::current().stop();
             })
             .finish()
             .wait(ctx)


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Fix `test_weak_address` by waiting for the delay future to resolve.
Fix `test_stream_timeout` by relaxing the timeout duration and panic on non timed out output.
Separate actors for `tests::test_fut` between different tests.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
