### PR TITLE
Replace the Into implement to From<Addr> for Recipient and WeakRecipient

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -5,8 +5,10 @@
 * Remove `fut::IntoActorFuture` trait. [#475]
 * Remove `fut::future::WrapFuture`'s `Output` associated type. [#475]
 * Remove `fut::stream::WrapStream`'s `Item` associated type. [#475]
+* Replace the `Into` implementation to `From<Addr>` for `Recipient` and `WeakRecipient`. [#479]
 
 [#475]: https://github.com/actix/actix/pull/475
+[#479]: https://github.com/actix/actix/pull/479
 
 
 ## 0.11.0-beta.3 - 2021-03-03

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -282,14 +282,14 @@ where
     }
 }
 
-impl<A: Actor, M: Message + Send + 'static> Into<Recipient<M>> for Addr<A>
+impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for Recipient<M>
 where
     A: Handler<M>,
     M::Result: Send,
     A::Context: ToEnvelope<A, M>,
 {
-    fn into(self) -> Recipient<M> {
-        Recipient::new(Box::new(self.tx))
+    fn from(addr: Addr<A>) -> Self {
+        Recipient::new(Box::new(addr.tx))
     }
 }
 
@@ -376,25 +376,25 @@ where
     }
 }
 
-impl<A: Actor, M: Message + Send + 'static> Into<WeakRecipient<M>> for Addr<A>
+impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for WeakRecipient<M>
 where
     A: Handler<M>,
     M::Result: Send,
     A::Context: ToEnvelope<A, M>,
 {
-    fn into(self) -> WeakRecipient<M> {
-        self.downgrade().recipient()
+    fn from(addr: Addr<A>) -> WeakRecipient<M> {
+        addr.downgrade().recipient()
     }
 }
 
-impl<A: Actor, M: Message + Send + 'static> Into<WeakRecipient<M>> for WeakAddr<A>
+impl<A: Actor, M: Message + Send + 'static> From<WeakAddr<A>> for WeakRecipient<M>
 where
     A: Handler<M>,
     M::Result: Send,
     A::Context: ToEnvelope<A, M>,
 {
-    fn into(self) -> WeakRecipient<M> {
-        WeakRecipient::new(Box::new(self.wtx))
+    fn from(addr: WeakAddr<A>) -> WeakRecipient<M> {
+        WeakRecipient::new(Box::new(addr.wtx))
     }
 }
 


### PR DESCRIPTION
According to the [C-CONV-TRAITS](https://rust-lang.github.io/api-guidelines/interoperability.html#c-conv-traits) of Rust API Guidelines,
The following conversion traits should never be implemented:
- `Into`
- `TryInto`

These traits have a blanket impl based on `From` and `TryFrom`. Implement those instead.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Code Style


## PR Checklist
Check your PR fulfills the following:


- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt
