### PR TITLE
add ActorFutureExt::and_then

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,8 @@
 # CHANGES
 
 ## Unreleased - 2021-xx-xx
+### Added
+* Added `ActorFutureExt::and_then` combinator for chaining actor futures.
 
 
 ## 0.11.0 - 2021-03-21

--- a/actix/src/fut/future/and_then.rs
+++ b/actix/src/fut/future/and_then.rs
@@ -1,0 +1,75 @@
+use std::pin::Pin;
+use std::task::{self, Poll};
+
+use futures_core::ready;
+use pin_project_lite::pin_project;
+
+use crate::actor::Actor;
+use crate::fut::ActorFuture;
+
+pin_project! {
+    /// Future for the `and_then` combinator, chaining computations on the end of
+    /// another future regardless of its outcome.
+    ///
+    /// This is created by the `Future::and_then` method.
+    #[project = ThenProj]
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless polled"]
+    pub enum AndThen<A, B, F> {
+        First {
+            #[pin]
+            fut1: A,
+            data: Option<F>,
+        },
+        Second {
+            #[pin]
+            fut2: B
+        },
+        Empty,
+    }
+}
+
+pub(super) fn new<A, B, F, Act>(future: A, f: F) -> AndThen<A, B, F>
+where
+    A: ActorFuture<Act>,
+    B: ActorFuture<Act>,
+    Act: Actor,
+{
+    AndThen::First {
+        fut1: future,
+        data: Some(f),
+    }
+}
+
+impl<A, B, F, Act, TA, TB, E> ActorFuture<Act> for AndThen<A, B, F>
+where
+    A: ActorFuture<Act, Output = Result<TA, E>>,
+    B: ActorFuture<Act, Output = Result<TB, E>>,
+    F: FnOnce(TA, &mut Act, &mut Act::Context) -> B,
+    Act: Actor,
+{
+    type Output = B::Output;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        act: &mut Act,
+        ctx: &mut Act::Context,
+        task: &mut task::Context<'_>,
+    ) -> Poll<B::Output> {
+        match self.as_mut().project() {
+            ThenProj::First { fut1, data } => {
+                let res = ready!(fut1.poll(act, ctx, task))?;
+                let data = data.take().unwrap();
+                let fut2 = data(res, act, ctx);
+                self.set(AndThen::Second { fut2 });
+                self.poll(act, ctx, task)
+            }
+            ThenProj::Second { fut2 } => {
+                let res = ready!(fut2.poll(act, ctx, task));
+                self.set(AndThen::Empty);
+                Poll::Ready(res)
+            }
+            ThenProj::Empty => panic!("ActorFuture polled after finish"),
+        }
+    }
+}


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Added `ActorFutureExt::and_then` combinator for chaining actor futures that output `Result<T, E>` type. 
`AndThen` would be able to map the Ok<T> variant to another actor future that have a different output.



<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
