### PR TITLE
Change return value to `Result` for `SinkWriter::write`

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -8,10 +8,12 @@
 
 ### Changed
 - Make `Context::new` public. [#491]
+- `SinkWriter::write` returns `Result` instead of `Option`. [#499]
 
 [#419]: https://github.com/actix/actix/pull/419
 [#491]: https://github.com/actix/actix/pull/491
 [#493]: https://github.com/actix/actix/pull/493
+[#499]: https://github.com/actix/actix/pull/499
 
 
 ## 0.11.1 - 2021-03-23

--- a/actix/src/io.rs
+++ b/actix/src/io.rs
@@ -442,13 +442,13 @@ impl<I: 'static, S: Sink<I> + Unpin + 'static> SinkWrite<I, S> {
     /// Queues an item to be sent to the sink.
     ///
     /// Returns unsent item if sink is closing or closed.
-    pub fn write(&mut self, item: I) -> Option<I> {
+    pub fn write(&mut self, item: I) -> Result<(), I> {
         if self.inner.borrow().closing_flag.is_empty() {
             self.inner.borrow_mut().buffer.push_back(item);
             self.notify_task();
-            None
+            Ok(())
         } else {
-            Some(item)
+            Err(item)
         }
     }
 


### PR DESCRIPTION
## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
Resolves the changes discussed in #498. `SinkWriter::write` should return a `Result` instead of an `Option`.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
Closes #498.