### PR TITLE
Implement a From for ActorResponse to avoid double boxing

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -4,6 +4,11 @@
 ### Removed
 - Removed `Resolver` actor [#451]
 
+### Added
+- Add a `From<Pin<Box<dyn ActorFuture + 'static>>>` implementation for `ActorResponse`. [#509]
+
+[#509]: https://github.com/actix/actix/pull/509
+
 ## 0.12.0 - 2021-06-06
 ### Added
 * Add `fut::try_future::ActorTryFuture`. [#419]

--- a/actix/src/handler.rs
+++ b/actix/src/handler.rs
@@ -507,6 +507,16 @@ where
     }
 }
 
+impl<A: Actor, I> From<Pin<Box<dyn ActorFuture<A, Output = I> + 'static>>>
+    for ActorResponse<A, I>
+{
+    fn from(fut: Pin<Box<dyn ActorFuture<A, Output = I> + 'static>>) -> Self {
+        Self {
+            item: ActorResponseTypeItem::Fut(fut),
+        }
+    }
+}
+
 macro_rules! SIMPLE_RESULT {
     ($type:ty) => {
         impl<A, M> MessageResponse<A, M> for $type


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Feature


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] ~~Documentation comments have been added / updated.~~
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
This implementation allows for users to use `ActorResponse` with `Pin<Box<dyn ActorFuture + 'static>>` without causing double boxing.


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
