### PR TITLE
Implement debug addr weakaddr

### DIFF
--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -179,11 +179,9 @@ impl<A: Actor> Hash for Addr<A> {
     }
 }
 
-impl <A: Actor> fmt::Debug for Addr<A> {
+impl<A: Actor> fmt::Debug for Addr<A> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Addr")
-            .field("tx",&self.tx)
-            .finish()
+        fmt.debug_struct("Addr").field("tx", &self.tx).finish()
     }
 }
 
@@ -230,7 +228,7 @@ impl<A: Actor> Clone for WeakAddr<A> {
 }
 
 impl<A: Actor> fmt::Debug for WeakAddr<A> {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("WeakAddr")
             .field("wtx", &self.wtx)
             .finish()

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -1,3 +1,4 @@
+use std::fmt::Formatter;
 use std::hash::{Hash, Hasher};
 use std::{error, fmt};
 
@@ -73,7 +74,6 @@ impl<T> fmt::Display for SendError<T> {
 }
 
 /// The address of an actor.
-#[derive(Debug)]
 pub struct Addr<A: Actor> {
     tx: AddressSender<A>,
 }
@@ -179,8 +179,15 @@ impl<A: Actor> Hash for Addr<A> {
     }
 }
 
+impl <A: Actor> fmt::Debug for Addr<A> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Addr")
+            .field("tx",&self.tx)
+            .finish()
+    }
+}
+
 /// A weakly referenced counterpart to `Addr<A>`.
-#[derive(Debug)]
 pub struct WeakAddr<A: Actor> {
     wtx: WeakAddressSender<A>,
 }
@@ -219,6 +226,14 @@ impl<A: Actor> Clone for WeakAddr<A> {
         WeakAddr {
             wtx: self.wtx.clone(),
         }
+    }
+}
+
+impl<A: Actor> fmt::Debug for WeakAddr<A> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result{
+        fmt.debug_struct("WeakAddr")
+            .field("wtx", &self.wtx)
+            .finish()
     }
 }
 


### PR DESCRIPTION

## PR Type
Added Debug manually for Addr,WeakAddr
Refactor



## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x ] Format code with the latest stable rustfmt


## Overview
Currently we use derive trait for Debug.

`
#[derive(Debug)]
pub struct Addr<A: Actor> {
    tx: AddressSender<A>,
}

`
---
Have implemented a Debug Manually

`
impl<A: Actor> fmt::Debug for Addr<A> {
    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
        fmt.debug_struct("Addr").field("tx", &self.tx).finish()
    }
}
`


[Ticket](https://github.com/actix/actix/issues/506)
Closes #506 
