### PR TITLE
fix: clippy::doc_markdown

### DIFF
--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -562,10 +562,7 @@ impl<A: Actor> WeakAddressSender<A> {
     ///
     /// Returns [`None`] if the actor has since been dropped.
     pub fn upgrade(&self) -> Option<AddressSender<A>> {
-        match Weak::upgrade(&self.inner) {
-            Some(inner) => Some(AddressSenderProducer { inner }.sender()),
-            None => None,
-        }
+        Weak::upgrade(&self.inner).map(|inner| AddressSenderProducer { inner }.sender())
     }
 }
 
@@ -577,7 +574,7 @@ where
     M: Message + Send + 'static,
 {
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>> {
-        if let Some(inner) = WeakAddressSender::upgrade(&self) {
+        if let Some(inner) = WeakAddressSender::upgrade(self) {
             Some(Box::new(inner))
         } else {
             None

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -138,7 +138,7 @@ impl<A: Actor> Addr<A> {
         }
     }
 
-    /// Returns the `Recipient` for a specific message type.
+    /// Returns the [`Recipient`] for a specific message type.
     pub fn recipient<M: 'static>(self) -> Recipient<M>
     where
         A: Handler<M>,
@@ -149,7 +149,7 @@ impl<A: Actor> Addr<A> {
         self.into()
     }
 
-    /// Returns a downgraded `WeakAddr`.
+    /// Returns a downgraded [`WeakAddr`].
     pub fn downgrade(&self) -> WeakAddr<A> {
         WeakAddr {
             wtx: self.tx.downgrade(),
@@ -186,7 +186,7 @@ pub struct WeakAddr<A: Actor> {
 }
 
 impl<A: Actor> WeakAddr<A> {
-    /// Attempts to upgrade the `WeakAddr<A>` pointer to an `Addr<A>`.
+    /// Attempts to upgrade the [`WeakAddr<A>`] pointer to an [`Addr<A>`].
     ///
     /// Returns `None` if the actor has since been dropped or the
     /// underlying address is disconnected.
@@ -222,7 +222,7 @@ impl<A: Actor> Clone for WeakAddr<A> {
     }
 }
 
-/// The `Recipient` type allows to send one specific message to an
+/// The [`Recipient`] type allows to send one specific message to an
 /// actor.
 ///
 /// You can get a recipient using the `Addr::recipient()` method. It

--- a/actix/src/contextimpl.rs
+++ b/actix/src/contextimpl.rs
@@ -65,7 +65,7 @@ where
     A::Context: AsyncContext<A>,
 {
     #[inline]
-    /// Create new ContextParts instance
+    /// Create new [`ContextParts`] instance
     pub fn new(addr: AddressSenderProducer<A>) -> Self {
         ContextParts {
             addr,

--- a/actix/src/fut/future/mod.rs
+++ b/actix/src/fut/future/mod.rs
@@ -24,9 +24,9 @@ mod timeout;
 /// Trait for types which are a placeholder of a value that may become
 /// available at some later point in time.
 ///
-/// `ActorFuture` is very similar to a regular `Future`, only with subsequent combinator closures accepting the actor and its context, in addition to the result.
+/// [`ActorFuture`] is very similar to a regular [`Future`], only with subsequent combinator closures accepting the actor and its context, in addition to the result.
 ///
-/// `ActorFuture` allows for use cases where future processing requires access to the actor or its context.
+/// [`ActorFuture`] allows for use cases where future processing requires access to the actor or its context.
 ///
 /// Here is an example of a handler on a single actor, deferring work to another actor, and
 /// then updating the initiating actor's state:
@@ -112,7 +112,7 @@ mod timeout;
 ///
 /// ```
 ///
-/// See also [into_actor](trait.WrapFuture.html#tymethod.into_actor), which provides future conversion using trait
+/// See also [`into_actor`](trait.WrapFuture.html#tymethod.into_actor), which provides future conversion using trait
 pub trait ActorFuture<A: Actor> {
     /// The type of value that this future will resolved with if it is
     /// successful.
@@ -160,7 +160,7 @@ pub trait ActorFutureExt<A: Actor>: ActorFuture<A> {
 
     /// Wrap the future in a Box, pinning it.
     ///
-    /// A shortcut for wrapping in [`Box::pin`](std::boxed::Box::pin).
+    /// A shortcut for wrapping in [`Box::pin`].
     fn boxed_local(self) -> LocalBoxActorFuture<A, Self::Output>
     where
         Self: Sized + 'static,
@@ -176,7 +176,7 @@ where
 {
 }
 
-/// Type alias for a pinned box ActorFuture trait object.
+/// Type alias for a pinned box [`ActorFuture`] trait object.
 pub type LocalBoxActorFuture<A, I> = Pin<Box<dyn ActorFuture<A, Output = I>>>;
 
 impl<F, A> ActorFuture<A> for Box<F>
@@ -214,7 +214,7 @@ where
     }
 }
 
-/// Helper trait that allows conversion of normal future into `ActorFuture`
+/// Helper trait that allows conversion of normal future into [`ActorFuture`]
 pub trait WrapFuture<A>
 where
     A: Actor,
@@ -226,7 +226,7 @@ where
     #[doc(hidden)]
     fn actfuture(self) -> Self::Future;
 
-    /// Convert normal future to a ActorFuture
+    /// Convert normal future to a [`ActorFuture`]
     fn into_actor(self, a: &A) -> Self::Future;
 }
 
@@ -255,11 +255,11 @@ pin_project! {
     }
 }
 
-/// Converts normal future into `ActorFuture`, allowing its processing to
+/// Converts normal future into [`ActorFuture`], allowing its processing to
 /// use the actor's state.
 ///
-/// See the documentation for [ActorFuture](trait.ActorFuture.html) for a practical example involving both
-/// `wrap_future` and `ActorFuture`
+/// See the documentation for [`ActorFuture`] for a practical example involving both
+/// [`wrap_future`] and [`ActorFuture`]
 pub fn wrap_future<F, A>(f: F) -> FutureWrap<F, A>
 where
     F: Future,

--- a/actix/src/fut/future/result.rs
+++ b/actix/src/fut/future/result.rs
@@ -1,4 +1,4 @@
-//! Definition of the `Result` (immediately finished) combinator
+//! Definition of the [`Ready`] (immediately finished) combinator
 
 use std::{
     future::Future,

--- a/actix/src/fut/future/then.rs
+++ b/actix/src/fut/future/then.rs
@@ -8,7 +8,7 @@ use crate::actor::Actor;
 use crate::fut::ActorFuture;
 
 pin_project! {
-    /// Future for the `then` combinator, chaining computations on the end of
+    /// Future for the [`then`](super::ActorFutureExt::then) combinator, chaining computations on the end of
     /// another future regardless of its outcome.
     ///
     /// This is created by the `ActorFuture::then` method.

--- a/actix/src/fut/future/timeout.rs
+++ b/actix/src/fut/future/timeout.rs
@@ -10,10 +10,10 @@ use crate::clock::{sleep, Sleep};
 use crate::fut::ActorFuture;
 
 pin_project! {
-    /// Future for the `timeout` combinator, interrupts computations if it takes
-    /// more than `timeout`.
+    /// Future for the [`timeout`](super::ActorFutureExt::timeout) combinator, interrupts computations if it takes
+    /// more than [`timeout`](super::ActorFutureExt::timeout).
     ///
-    /// This is created by the `ActorFuture::timeout()` method.
+    /// This is created by the [`timeout`](super::ActorFutureExt::timeout) method.
     #[derive(Debug)]
     #[must_use = "futures do nothing unless polled"]
     pub struct Timeout<F>{

--- a/actix/src/fut/stream/mod.rs
+++ b/actix/src/fut/stream/mod.rs
@@ -180,7 +180,7 @@ where
     #[doc(hidden)]
     fn actstream(self) -> Self::Stream;
 
-    /// Convert normal stream to a ActorStream
+    /// Convert normal stream to a [`ActorStream`]
     fn into_actor(self, a: &A) -> Self::Stream;
 }
 

--- a/actix/src/handler.rs
+++ b/actix/src/handler.rs
@@ -20,7 +20,7 @@ where
 {
     /// The type of value that this handler will return.
     ///
-    /// Check the [MessageResponse] trait for some details
+    /// Check the [`MessageResponse`] trait for some details
     /// on how a message can be responded to.
     type Result: MessageResponse<Self, M>;
 
@@ -51,7 +51,7 @@ where
     type Result = M::Result;
 }
 
-/// A helper type that implements the `MessageResponse` trait.
+/// A helper type that implements the [`MessageResponse`] trait.
 ///
 /// # Examples
 /// ```no_run
@@ -85,13 +85,13 @@ pub struct MessageResult<M: Message>(pub M::Result);
 /// internal state or context, e.g., it can yield at critical sessions.
 /// When the actor starts to process this future, it will not pull any other
 /// spawned futures until this one as been completed.
-/// Check [ActorFuture] for available methods for accessing Actor's
+/// Check [`ActorFuture`] for available methods for accessing Actor's
 /// internal state.
 ///
 /// ## Note
 /// The runtime itself is not blocked in the process, only the Actor,
 /// other futures, and therefore, other actors are still allowed to make
-/// progress when this [AtomicResponse] is used.
+/// progress when this [`AtomicResponse`] is used.
 ///
 /// # Examples
 /// On the following example, the response to `Msg` would always be 29
@@ -154,13 +154,13 @@ where
 /// A specialized actor future for asynchronous message handling.
 ///
 /// Intended be used when the future returned will, at some point, need to access Actor's internal
-/// state or context in order to finish. Check [ActorFuture] for available methods for accessing
+/// state or context in order to finish. Check [`ActorFuture`] for available methods for accessing
 /// Actor's internal state.
 ///
 /// # Note
-/// It's important to keep in mind that the provided [AsyncContext], does not enforce the poll of
-/// any [ActorFuture] to be exclusive. Therefore, if other instances of [ActorFuture] are spawned
-/// into this Context **their execution won't necessarily be atomic**. Check [AtomicResponse] if you
+/// It's important to keep in mind that the provided [`AsyncContext`], does not enforce the poll of
+/// any [`ActorFuture`] to be exclusive. Therefore, if other instances of [`ActorFuture`] are spawned
+/// into this Context **their execution won't necessarily be atomic**. Check [`AtomicResponse`] if you
 /// need exclusive access over the actor.
 ///
 /// # Examples
@@ -234,19 +234,19 @@ pub type ResponseFuture<I> = Pin<Box<dyn Future<Output = I>>>;
 /// A trait which defines message responses.
 ///
 /// We offer implementation for some common language types, if you need
-/// to respond with a new type you can use [MessageResult].
+/// to respond with a new type you can use [`MessageResult`].
 ///
-/// If `Actor::Context` implements [AsyncContext] it's possible to handle
+/// If `Actor::Context` implements [`AsyncContext`] it's possible to handle
 /// the message asynchronously.
 /// For asynchronous message handling we offer the following possible response types:
-/// - [ResponseFuture] should be used for when the future returned doesn't
+/// - [`ResponseFuture`] should be used for when the future returned doesn't
 ///   need to access Actor's internal state or context to progress, either
 ///   because it's completely agnostic to it or because the required data has
 ///   already been moved to it and it won't need Actor state to continue.
-/// - [ResponseActFuture] should be used when the future returned
+/// - [`ResponseActFuture`] should be used when the future returned
 ///   will, at some point, need to access Actor's internal state or context
 ///   in order to finish.
-/// - [AtomicResponse] should be used when the future returned needs exclusive
+/// - [`AtomicResponse`] should be used when the future returned needs exclusive
 ///   access to  Actor's internal state or context.
 pub trait MessageResponse<A: Actor, M: Message> {
     fn handle(self, ctx: &mut A::Context, tx: Option<OneshotSender<M::Result>>);
@@ -329,7 +329,7 @@ where
     }
 }
 
-/// MessageResponse trait impl to enable the use of any `I: 'static` with asynchronous
+/// [`MessageResponse`] trait impl to enable the use of any `I: 'static` with asynchronous
 /// message handling
 ///
 /// # Examples

--- a/actix/src/io.rs
+++ b/actix/src/io.rs
@@ -298,7 +298,7 @@ where
     }
 }
 
-/// A wrapper for the `AsyncWrite` and `Encoder` types. The AsyncWrite will be flushed when this
+/// A wrapper for the `AsyncWrite` and `Encoder` types. The [`AsyncWrite`] will be flushed when this
 /// struct is dropped.
 pub struct FramedWrite<I, T: AsyncWrite + Unpin, U: Encoder<I>> {
     enc: U,

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -17,7 +17,7 @@
 //! - Actor communication in a local/thread context
 //! - Using Futures for asynchronous message handling
 //! - Actor supervision
-//! - Typed messages (No `Any` type). Generic messages are allowed
+//! - Typed messages (No [`Any`](std::any::Any) type). Generic messages are allowed
 //! - Runs on stable Rust 1.40+
 //!
 //! ## Package feature
@@ -25,7 +25,12 @@
 
 #![allow(clippy::needless_doctest_main)]
 #![deny(nonstandard_style, rust_2018_idioms)]
-#![warn(deprecated_in_future, trivial_casts, trivial_numeric_casts)]
+#![warn(
+    deprecated_in_future,
+    trivial_casts,
+    trivial_numeric_casts,
+    clippy::doc_markdown
+)]
 // TODO: temporary allow deprecated until resolver actor is removed.
 #![allow(deprecated)]
 

--- a/actix/src/sync.rs
+++ b/actix/src/sync.rs
@@ -4,7 +4,7 @@
 //! This is useful for CPU bound, or concurrent workloads. There can only be
 //! a single Sync Actor type on a `SyncArbiter`. This means you can't have
 //! Actor type A and B, sharing the same thread pool. You need to create two
-//! SyncArbiters and have A and B spawn on unique `SyncArbiter`s respectively.
+//! [`SyncArbiter`]s and have A and B spawn on unique `SyncArbiter`s respectively.
 //! For more information and examples, see `SyncArbiter`
 use std::future::Future;
 use std::pin::Pin;
@@ -26,9 +26,9 @@ use crate::address::{
 use crate::context::Context;
 use crate::handler::{Handler, Message, MessageResponse};
 
-/// SyncArbiter provides the resources for a single Sync Actor to run on a dedicated
+/// [`SyncArbiter`] provides the resources for a single Sync Actor to run on a dedicated
 /// thread or threads. This is generally used for CPU bound concurrent workloads. It's
-/// important to note, that the SyncArbiter generates a single address for the pool
+/// important to note, that the [`SyncArbiter`] generates a single address for the pool
 /// of hosted Sync Actors. Any message sent to this Address, will be operated on by
 /// a single Sync Actor from the pool.
 ///
@@ -189,9 +189,9 @@ where
 }
 
 /// Sync actor execution context. This is used instead of impl Actor for your Actor
-/// instead of Context, if you intend this actor to run in a SyncArbiter.
+/// instead of Context, if you intend this actor to run in a [`SyncArbiter`].
 ///
-/// Unlike Context, an Actor that uses a SyncContext can not be stopped
+/// Unlike Context, an Actor that uses a [`SyncContext`] can not be stopped
 /// by calling `stop` or `terminate`: Instead, these trigger a restart of
 /// the Actor. Similar, returning `false` from `fn stopping` can not prevent
 /// the restart or termination of the Actor.
@@ -298,14 +298,14 @@ impl<A> ActorContext for SyncContext<A>
 where
     A: Actor<Context = Self>,
 {
-    /// Stop the current Actor. SyncContext will stop the existing Actor, and restart
+    /// Stop the current Actor. [`SyncContext`] will stop the existing Actor, and restart
     /// a new Actor of the same type to replace it.
     fn stop(&mut self) {
         self.stopping = true;
         self.state = ActorState::Stopping;
     }
 
-    /// Terminate the current Actor. SyncContext will terminate the existing Actor, and restart
+    /// Terminate the current Actor. [`SyncContext`] will terminate the existing Actor, and restart
     /// a new Actor of the same type to replace it.
     fn terminate(&mut self) {
         self.stopping = true;


### PR DESCRIPTION

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other: docs cleanup


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
Hi there, I just ran clippy and though it'd also be nice to make use of those fancy new doc links that rustdoc allows nowadays.
Besides that there's nothing that changed
Thanks, have a nice day


<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
