### PR TITLE
Implement Clone for WeakRecipient

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -3,6 +3,8 @@
 ## Unreleased - 2021-xx-xx
 ### Removed
 - Removed `Resolver` actor [#451]
+- Implement `Clone` for `WeakRecipient` [#518]
+- 
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -4,7 +4,9 @@
 ### Removed
 - Removed `Resolver` actor [#451]
 - Implement `Clone` for `WeakRecipient` [#518]
-- 
+- Extend Sender trait by a downgrade function [#518]
+- Make `WeakSender` trait public rather than crate-public [#518]
+- Add `downgrade` functionality to `Recipient` to obtain a `WeakRecipient` [#518]
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -7,6 +7,7 @@
 - Extend Sender trait by a downgrade function [#518]
 - Make `WeakSender` trait public rather than crate-public [#518]
 - Add `downgrade` functionality to `Recipient` to obtain a `WeakRecipient` [#518]
+- Add `From` conversion from `Recipient` to `WeakRecipient` [#518]
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -43,7 +43,8 @@ where
 
     fn connected(&self) -> bool;
 
-    fn downgrade(&self) -> Box<dyn WeakSender<M>>;
+    /// Returns a downgraded sender, where the sender is downgraded into its weak counterpart
+    fn downgrade(&self) -> Box<dyn WeakSender<M> + Sync + 'static>;
 }
 
 impl<S, M> Sender<M> for Box<S>
@@ -76,7 +77,7 @@ where
         (**self).connected()
     }
 
-    fn downgrade(&self) -> Box<dyn WeakSender<M>> {
+    fn downgrade(&self) -> Box<dyn WeakSender<M> + Sync + 'static> {
         (**self).downgrade()
     }
 }
@@ -498,7 +499,7 @@ where
         self.connected()
     }
 
-    fn downgrade(&self) -> Box<dyn WeakSender<M>> {
+    fn downgrade(&self) -> Box<dyn WeakSender<M> + Sync + 'static> {
        Box::new(WeakAddressSender {
            inner:Arc::downgrade(&self.inner)
        } )

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -500,9 +500,9 @@ where
     }
 
     fn downgrade(&self) -> Box<dyn WeakSender<M> + Sync + 'static> {
-       Box::new(WeakAddressSender {
-           inner:Arc::downgrade(&self.inner)
-       } )
+        Box::new(WeakAddressSender {
+            inner: Arc::downgrade(&self.inner),
+        })
     }
 }
 

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -42,6 +42,8 @@ where
     fn hash(&self) -> usize;
 
     fn connected(&self) -> bool;
+
+    fn downgrade(&self) -> Box<dyn WeakSender<M>>;
 }
 
 impl<S, M> Sender<M> for Box<S>
@@ -73,9 +75,13 @@ where
     fn connected(&self) -> bool {
         (**self).connected()
     }
+
+    fn downgrade(&self) -> Box<dyn WeakSender<M>> {
+        (**self).downgrade()
+    }
 }
 
-pub(crate) trait WeakSender<M>: Send
+pub trait WeakSender<M>: Send
 where
     M::Result: Send,
     M: Message + Send,
@@ -490,6 +496,12 @@ where
 
     fn connected(&self) -> bool {
         self.connected()
+    }
+
+    fn downgrade(&self) -> Box<dyn WeakSender<M>> {
+       Box::new(WeakAddressSender {
+           inner:Arc::downgrade(&self.inner)
+       } )
     }
 }
 

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -391,8 +391,10 @@ where
 }
 
 impl<M> From<Recipient<M>> for WeakRecipient<M>
-where M: Message + Send,
-M::Result : Send {
+where
+    M: Message + Send,
+    M::Result: Send,
+{
     fn from(recipient: Recipient<M>) -> Self {
         recipient.downgrade()
     }

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -290,6 +290,13 @@ where
     pub fn connected(&self) -> bool {
         self.tx.connected()
     }
+
+    /// Returns a downgraded `WeakRecipient`
+    pub fn downgrade(&self) -> WeakRecipient<M> {
+        WeakRecipient {
+            wtx : self.tx.downgrade()
+        }
+    }
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for Recipient<M>

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -390,6 +390,14 @@ where
     }
 }
 
+impl<M> From<Recipient<M>> for WeakRecipient<M>
+where M: Message + Send,
+M::Result : Send {
+    fn from(recipient: Recipient<M>) -> Self {
+        recipient.downgrade()
+    }
+}
+
 impl<M> WeakRecipient<M>
 where
     M: Message + Send,

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -372,11 +372,13 @@ where
 }
 
 impl<M> Clone for WeakRecipient<M>
-where M: Message + Send,
-M::Result: Send {
+where
+    M: Message + Send,
+    M::Result: Send,
+{
     fn clone(&self) -> Self {
         Self {
-            wtx : self.wtx.boxed()
+            wtx: self.wtx.boxed(),
         }
     }
 }

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -294,7 +294,7 @@ where
     /// Returns a downgraded `WeakRecipient`
     pub fn downgrade(&self) -> WeakRecipient<M> {
         WeakRecipient {
-            wtx : self.tx.downgrade()
+            wtx: self.tx.downgrade(),
         }
     }
 }

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -371,6 +371,16 @@ where
     }
 }
 
+impl<M> Clone for WeakRecipient<M>
+where M: Message + Send,
+M::Result: Send {
+    fn clone(&self) -> Self {
+        Self {
+            wtx : self.wtx.boxed()
+        }
+    }
+}
+
 impl<M> WeakRecipient<M>
 where
     M: Message + Send,

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -234,9 +234,18 @@ fn test_recipient_can_be_downgraded() {
     sys.block_on(async move {
         let addr = PingCounterActor::start_default();
         let strong_recipient: Recipient<Ping> = addr.clone().recipient();
+        // test the downgrade method
         let weak_recipient: WeakRecipient<Ping> = strong_recipient.downgrade();
-
+        // test the From trait
+        let converted_weak_recipient  = WeakRecipient::from(strong_recipient);
         weak_recipient
+            .upgrade()
+            .expect("upgrade of weak recipient must not fail here")
+            .send(Ping(0))
+            .await
+            .unwrap();
+
+              converted_weak_recipient
             .upgrade()
             .expect("upgrade of weak recipient must not fail here")
             .send(Ping(0))
@@ -244,8 +253,8 @@ fn test_recipient_can_be_downgraded() {
             .unwrap();
         let ping_count = addr.send(CountPings {}).await.unwrap();
         assert_eq!(
-            ping_count, 1,
-            "weak recipient must not fail to send a message"
+            ping_count, 2,
+            "weak recipients must not fail to send a message"
         );
     })
 }

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -231,17 +231,23 @@ fn test_weak_recipient_can_be_cloned() {
 fn test_recipient_can_be_downgraded() {
     let sys = System::new();
 
-    sys.block_on(
-        async move {
-            let addr = PingCounterActor::start_default();
-            let strong_recipient : Recipient<Ping> = addr.clone().recipient();
-            let weak_recipient : WeakRecipient<Ping> = strong_recipient.downgrade();
+    sys.block_on(async move {
+        let addr = PingCounterActor::start_default();
+        let strong_recipient: Recipient<Ping> = addr.clone().recipient();
+        let weak_recipient: WeakRecipient<Ping> = strong_recipient.downgrade();
 
-            weak_recipient.upgrade().expect("upgrade of weak recipient must not fail here").send(Ping(0)).await.unwrap();
-            let ping_count = addr.send(CountPings{}).await.unwrap();
-            assert_eq!(ping_count,1, "weak recipient must not fail to send a message");
-        }
-    )
+        weak_recipient
+            .upgrade()
+            .expect("upgrade of weak recipient must not fail here")
+            .send(Ping(0))
+            .await
+            .unwrap();
+        let ping_count = addr.send(CountPings {}).await.unwrap();
+        assert_eq!(
+            ping_count, 1,
+            "weak recipient must not fail to send a message"
+        );
+    })
 }
 
 #[test]

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -237,7 +237,7 @@ fn test_recipient_can_be_downgraded() {
         // test the downgrade method
         let weak_recipient: WeakRecipient<Ping> = strong_recipient.downgrade();
         // test the From trait
-        let converted_weak_recipient  = WeakRecipient::from(strong_recipient);
+        let converted_weak_recipient = WeakRecipient::from(strong_recipient);
         weak_recipient
             .upgrade()
             .expect("upgrade of weak recipient must not fail here")
@@ -245,7 +245,7 @@ fn test_recipient_can_be_downgraded() {
             .await
             .unwrap();
 
-              converted_weak_recipient
+        converted_weak_recipient
             .upgrade()
             .expect("upgrade of weak recipient must not fail here")
             .send(Ping(0))

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashSet, time::Duration};
 use std::mem::drop;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::{collections::HashSet, time::Duration};
 
 use actix_rt::time::sleep;
 
@@ -16,7 +16,6 @@ impl Message for Ping {
 
 struct MyActor(Arc<AtomicUsize>);
 
-
 impl Actor for MyActor {
     type Context = actix::Context<Self>;
 }
@@ -28,7 +27,6 @@ impl actix::Handler<Ping> for MyActor {
         self.0.fetch_add(1, Ordering::Relaxed);
     }
 }
-
 
 #[derive(Debug)]
 struct MyActor3;
@@ -75,7 +73,6 @@ impl actix::Handler<Ping> for PingCounterActor {
         self.ping_count.fetch_add(1, Ordering::SeqCst);
     }
 }
-
 
 impl actix::Handler<CountPings> for PingCounterActor {
     type Result = <CountPings as actix::Message>::Result;
@@ -209,10 +206,23 @@ fn test_weak_recipient_can_be_cloned() {
         let weak_recipient = addr.downgrade().recipient();
         let weak_recipient_clone = weak_recipient.clone();
 
-        weak_recipient.upgrade().expect("must be able to upgrade the weak recipient here").send(Ping(0)).await.expect("send must not fail");
-        weak_recipient_clone.upgrade().expect("must be able to upgrade the cloned weak recipient here").send(Ping(0)).await.expect("send must not fail");
+        weak_recipient
+            .upgrade()
+            .expect("must be able to upgrade the weak recipient here")
+            .send(Ping(0))
+            .await
+            .expect("send must not fail");
+        weak_recipient_clone
+            .upgrade()
+            .expect("must be able to upgrade the cloned weak recipient here")
+            .send(Ping(0))
+            .await
+            .expect("send must not fail");
         let pings = addr.send(CountPings {}).await.expect("send must not fail");
-        assert_eq!(pings, 2, "both the weak recipient and its clone must have sent a ping");
+        assert_eq!(
+            pings, 2,
+            "both the weak recipient and its clone must have sent a ping"
+        );
     })
 }
 


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated. (_rustdoc automatically shows the Clone trait implementation_)
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
* `WeakRecipients`, like strong `Recipients` can now be cloned.
* `Recipient` now offers a `downgrade` method to obtain a `WeakRecipient`, similar to `Addr` and `WeakAddr`
* `WeakRecipient` can be converted from a `Recipient` via the `From` trait.

Potentially breaking changes:
* The `Sender` trait now requires a `downgrade` method. This affects code that implements its own `Sender` traits. However, this is not what many users would do.

Non-Breaking Changes:
* `WeakSender` is now public instead of crate-public. This did not use to be required, but the `downgrade` method on the publich `Sender` trait forces this.

## Issue
Closes [#518](https://github.com/actix/actix/issues/518)
