### PR TITLE
implement `eq` for weak addr

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -11,7 +11,7 @@
 - Make `WeakSender` trait public rather than crate-public [#518]
 - Add `downgrade` functionality to `Recipient` to obtain a `WeakRecipient` [#518]
 - Add `From` conversion from `Recipient` to `WeakRecipient` [#518]
-
+- Add `PartialEq` to `WeakAddr` and `WeakAddressSender` [#523]
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -3,15 +3,15 @@
 ## Unreleased - 2021-xx-xx
 ### Changed
 - Updated minimum supported Rust version to 1.49.
-
-### Removed
-- Removed `Resolver` actor [#451]
 - Implement `Clone` for `WeakRecipient` [#518]
 - Extend Sender trait by a downgrade function [#518]
 - Make `WeakSender` trait public rather than crate-public [#518]
 - Add `downgrade` functionality to `Recipient` to obtain a `WeakRecipient` [#518]
 - Add `From` conversion from `Recipient` to `WeakRecipient` [#518]
 - Implement `PartialEq` and `Eq` to `WeakAddr` and `WeakAddressSender` [#523]
+
+### Removed
+- Removed `Resolver` actor [#451]
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -11,7 +11,7 @@
 - Make `WeakSender` trait public rather than crate-public [#518]
 - Add `downgrade` functionality to `Recipient` to obtain a `WeakRecipient` [#518]
 - Add `From` conversion from `Recipient` to `WeakRecipient` [#518]
-- Add `PartialEq` to `WeakAddr` and `WeakAddressSender` [#523]
+- Implement `PartialEq` and `Eq` to `WeakAddr` and `WeakAddressSender` [#523]
 
 ## 0.12.0 - 2021-06-06
 ### Added

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -92,8 +92,6 @@ where
     /// Returns [`None`] if the actor has since been dropped.
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>>;
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync>;
-    /// return a hash that uniquely identifies the destination that the weak sender points to
-    fn hash(&self) -> usize;
 }
 
 /// The transmission end of a channel which is used to send values.
@@ -145,7 +143,7 @@ impl<A: Actor> fmt::Debug for WeakAddressSender<A> {
 
 impl<A: Actor> PartialEq for WeakAddressSender<A> {
     fn eq(&self, other: &Self) -> bool {
-       self.inner.ptr_eq(&other.inner)
+        self.inner.ptr_eq(&other.inner)
     }
 }
 
@@ -604,11 +602,6 @@ where
 
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync> {
         Box::new(self.clone())
-    }
-
-    fn hash(&self) -> usize {
-        let hash: *const _ = self.inner.as_ptr();
-        hash as usize
     }
 }
 

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -141,6 +141,12 @@ impl<A: Actor> fmt::Debug for WeakAddressSender<A> {
     }
 }
 
+impl<A: Actor> PartialEq for WeakAddressSender<A> {
+    fn eq(&self, other: &Self) -> bool {
+       self.inner.ptr_eq(&other.inner)
+    }
+}
+
 trait AssertKinds: Send + Sync + Clone {}
 
 /// The receiving end of a channel which implements the `Stream` trait.

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -147,6 +147,8 @@ impl<A: Actor> PartialEq for WeakAddressSender<A> {
     }
 }
 
+impl<A: Actor> Eq for WeakAddressSender<A> {}
+
 trait AssertKinds: Send + Sync + Clone {}
 
 /// The receiving end of a channel which implements the `Stream` trait.

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -92,6 +92,8 @@ where
     /// Returns [`None`] if the actor has since been dropped.
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>>;
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync>;
+
+    fn hash(&self) -> usize;
 }
 
 /// The transmission end of a channel which is used to send values.
@@ -602,6 +604,11 @@ where
 
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync> {
         Box::new(self.clone())
+    }
+
+    fn hash(&self) -> usize {
+        let hash: *const _ = self.inner.as_ptr();
+        hash as usize
     }
 }
 

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -92,7 +92,7 @@ where
     /// Returns [`None`] if the actor has since been dropped.
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>>;
     fn boxed(&self) -> Box<dyn WeakSender<M> + Sync>;
-
+    /// return a hash that uniquely identifies the destination that the weak sender points to
     fn hash(&self) -> usize;
 }
 

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -94,11 +94,11 @@ impl<A: Actor> Addr<A> {
     /// The message is always queued, even if the mailbox for the receiver is full.
     /// If the mailbox is closed, the message is silently dropped.
     pub fn do_send<M>(&self, msg: M)
-        where
-            M: Message + Send,
-            M::Result: Send,
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
+    where
+        M: Message + Send,
+        M::Result: Send,
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
     {
         let _ = self.tx.do_send(msg);
     }
@@ -108,11 +108,11 @@ impl<A: Actor> Addr<A> {
     /// This method fails if actor's mailbox is full or closed. This
     /// method registers the current task in the receiver's queue.
     pub fn try_send<M>(&self, msg: M) -> Result<(), SendError<M>>
-        where
-            M: Message + Send + 'static,
-            M::Result: Send,
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
+    where
+        M: Message + Send + 'static,
+        M::Result: Send,
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
     {
         self.tx.try_send(msg, true)
     }
@@ -124,11 +124,11 @@ impl<A: Actor> Addr<A> {
     /// returned `Future` object gets dropped, the message is
     /// cancelled.
     pub fn send<M>(&self, msg: M) -> Request<A, M>
-        where
-            M: Message + Send + 'static,
-            M::Result: Send,
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
+    where
+        M: Message + Send + 'static,
+        M::Result: Send,
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
     {
         match self.tx.send(msg) {
             Ok(rx) => Request::new(Some(rx), None),
@@ -139,11 +139,11 @@ impl<A: Actor> Addr<A> {
 
     /// Returns the [`Recipient`] for a specific message type.
     pub fn recipient<M: 'static>(self) -> Recipient<M>
-        where
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
-            M: Message + Send,
-            M::Result: Send,
+    where
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
+        M: Message + Send,
+        M::Result: Send,
     {
         self.into()
     }
@@ -208,11 +208,11 @@ impl<A: Actor> WeakAddr<A> {
     }
 
     pub fn recipient<M: 'static>(self) -> WeakRecipient<M>
-        where
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
-            M: Message + Send,
-            M::Result: Send,
+    where
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
+        M: Message + Send,
+        M::Result: Send,
     {
         self.into()
     }
@@ -245,17 +245,17 @@ impl<A: Actor> PartialEq for WeakAddr<A> {
 /// You can get a recipient using the `Addr::recipient()` method. It is possible
 /// to use the `Clone::clone()` method to get a cloned recipient.
 pub struct Recipient<M: Message>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     tx: Box<dyn Sender<M> + Sync>,
 }
 
 impl<M> Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     /// Creates a new recipient.
     pub(crate) fn new(tx: Box<dyn Sender<M> + Sync>) -> Recipient<M> {
@@ -306,10 +306,10 @@ impl<M> Recipient<M>
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for Recipient<M>
-    where
-        A: Handler<M>,
-        M::Result: Send,
-        A::Context: ToEnvelope<A, M>,
+where
+    A: Handler<M>,
+    M::Result: Send,
+    A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: Addr<A>) -> Self {
         Recipient::new(Box::new(addr.tx))
@@ -317,9 +317,9 @@ impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for Recipient<M>
 }
 
 impl<M> Clone for Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn clone(&self) -> Recipient<M> {
         Recipient {
@@ -329,9 +329,9 @@ impl<M> Clone for Recipient<M>
 }
 
 impl<M> PartialEq for Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn eq(&self, other: &Self) -> bool {
         self.tx.hash() == other.tx.hash()
@@ -339,15 +339,16 @@ impl<M> PartialEq for Recipient<M>
 }
 
 impl<M> Eq for Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
-{}
+where
+    M: Message + Send,
+    M::Result: Send,
+{
+}
 
 impl<M> Hash for Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.tx.hash().hash(state)
@@ -355,9 +356,9 @@ impl<M> Hash for Recipient<M>
 }
 
 impl<M> fmt::Debug for Recipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "Recipient {{ /* omitted */ }}")
@@ -366,17 +367,17 @@ impl<M> fmt::Debug for Recipient<M>
 
 /// A weakly referenced counterpart to `Recipient<M>`
 pub struct WeakRecipient<M: Message>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     wtx: Box<dyn WeakSender<M> + Sync>,
 }
 
 impl<M> fmt::Debug for WeakRecipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "WeakRecipient {{ /* omitted */ }}")
@@ -384,9 +385,9 @@ impl<M> fmt::Debug for WeakRecipient<M>
 }
 
 impl<M> Clone for WeakRecipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn clone(&self) -> Self {
         Self {
@@ -395,18 +396,10 @@ impl<M> Clone for WeakRecipient<M>
     }
 }
 
-impl<M> PartialEq for WeakRecipient<M>
-    where M: Message + Send,
-          M::Result: Send {
-    fn eq(&self, other: &Self) -> bool {
-       self.wtx.hash() == other.wtx.hash()
-    }
-}
-
 impl<M> From<Recipient<M>> for WeakRecipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     fn from(recipient: Recipient<M>) -> Self {
         recipient.downgrade()
@@ -414,9 +407,9 @@ impl<M> From<Recipient<M>> for WeakRecipient<M>
 }
 
 impl<M> WeakRecipient<M>
-    where
-        M: Message + Send,
-        M::Result: Send,
+where
+    M: Message + Send,
+    M::Result: Send,
 {
     pub(crate) fn new(wtx: Box<dyn WeakSender<M> + Sync>) -> WeakRecipient<M> {
         WeakRecipient { wtx }
@@ -429,10 +422,10 @@ impl<M> WeakRecipient<M>
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for WeakRecipient<M>
-    where
-        A: Handler<M>,
-        M::Result: Send,
-        A::Context: ToEnvelope<A, M>,
+where
+    A: Handler<M>,
+    M::Result: Send,
+    A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: Addr<A>) -> WeakRecipient<M> {
         addr.downgrade().recipient()
@@ -440,10 +433,10 @@ impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for WeakRecipient<M>
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<WeakAddr<A>> for WeakRecipient<M>
-    where
-        A: Handler<M>,
-        M::Result: Send,
-        A::Context: ToEnvelope<A, M>,
+where
+    A: Handler<M>,
+    M::Result: Send,
+    A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: WeakAddr<A>) -> WeakRecipient<M> {
         WeakRecipient::new(Box::new(addr.wtx))

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -240,6 +240,8 @@ impl<A: Actor> PartialEq for WeakAddr<A> {
     }
 }
 
+impl<A: Actor> std::cmp::Eq for WeakAddr<A> {}
+
 /// The [`Recipient`] type allows to send one specific message to an actor.
 ///
 /// You can get a recipient using the `Addr::recipient()` method. It is possible

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -234,6 +234,12 @@ impl<A: Actor> fmt::Debug for WeakAddr<A> {
     }
 }
 
+impl<A: Actor> PartialEq for WeakAddr<A> {
+    fn eq(&self, other: &Self) -> bool {
+       self.wtx == other.wtx
+    }
+}
+
 /// The [`Recipient`] type allows to send one specific message to an actor.
 ///
 /// You can get a recipient using the `Addr::recipient()` method. It is possible

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -94,11 +94,11 @@ impl<A: Actor> Addr<A> {
     /// The message is always queued, even if the mailbox for the receiver is full.
     /// If the mailbox is closed, the message is silently dropped.
     pub fn do_send<M>(&self, msg: M)
-    where
-        M: Message + Send,
-        M::Result: Send,
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
+        where
+            M: Message + Send,
+            M::Result: Send,
+            A: Handler<M>,
+            A::Context: ToEnvelope<A, M>,
     {
         let _ = self.tx.do_send(msg);
     }
@@ -108,11 +108,11 @@ impl<A: Actor> Addr<A> {
     /// This method fails if actor's mailbox is full or closed. This
     /// method registers the current task in the receiver's queue.
     pub fn try_send<M>(&self, msg: M) -> Result<(), SendError<M>>
-    where
-        M: Message + Send + 'static,
-        M::Result: Send,
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
+        where
+            M: Message + Send + 'static,
+            M::Result: Send,
+            A: Handler<M>,
+            A::Context: ToEnvelope<A, M>,
     {
         self.tx.try_send(msg, true)
     }
@@ -124,11 +124,11 @@ impl<A: Actor> Addr<A> {
     /// returned `Future` object gets dropped, the message is
     /// cancelled.
     pub fn send<M>(&self, msg: M) -> Request<A, M>
-    where
-        M: Message + Send + 'static,
-        M::Result: Send,
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
+        where
+            M: Message + Send + 'static,
+            M::Result: Send,
+            A: Handler<M>,
+            A::Context: ToEnvelope<A, M>,
     {
         match self.tx.send(msg) {
             Ok(rx) => Request::new(Some(rx), None),
@@ -139,11 +139,11 @@ impl<A: Actor> Addr<A> {
 
     /// Returns the [`Recipient`] for a specific message type.
     pub fn recipient<M: 'static>(self) -> Recipient<M>
-    where
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M: Message + Send,
-        M::Result: Send,
+        where
+            A: Handler<M>,
+            A::Context: ToEnvelope<A, M>,
+            M: Message + Send,
+            M::Result: Send,
     {
         self.into()
     }
@@ -208,11 +208,11 @@ impl<A: Actor> WeakAddr<A> {
     }
 
     pub fn recipient<M: 'static>(self) -> WeakRecipient<M>
-    where
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M: Message + Send,
-        M::Result: Send,
+        where
+            A: Handler<M>,
+            A::Context: ToEnvelope<A, M>,
+            M: Message + Send,
+            M::Result: Send,
     {
         self.into()
     }
@@ -236,7 +236,7 @@ impl<A: Actor> fmt::Debug for WeakAddr<A> {
 
 impl<A: Actor> PartialEq for WeakAddr<A> {
     fn eq(&self, other: &Self) -> bool {
-       self.wtx == other.wtx
+        self.wtx == other.wtx
     }
 }
 
@@ -245,17 +245,17 @@ impl<A: Actor> PartialEq for WeakAddr<A> {
 /// You can get a recipient using the `Addr::recipient()` method. It is possible
 /// to use the `Clone::clone()` method to get a cloned recipient.
 pub struct Recipient<M: Message>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     tx: Box<dyn Sender<M> + Sync>,
 }
 
 impl<M> Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     /// Creates a new recipient.
     pub(crate) fn new(tx: Box<dyn Sender<M> + Sync>) -> Recipient<M> {
@@ -306,10 +306,10 @@ where
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for Recipient<M>
-where
-    A: Handler<M>,
-    M::Result: Send,
-    A::Context: ToEnvelope<A, M>,
+    where
+        A: Handler<M>,
+        M::Result: Send,
+        A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: Addr<A>) -> Self {
         Recipient::new(Box::new(addr.tx))
@@ -317,9 +317,9 @@ where
 }
 
 impl<M> Clone for Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn clone(&self) -> Recipient<M> {
         Recipient {
@@ -329,9 +329,9 @@ where
 }
 
 impl<M> PartialEq for Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn eq(&self, other: &Self) -> bool {
         self.tx.hash() == other.tx.hash()
@@ -339,16 +339,15 @@ where
 }
 
 impl<M> Eq for Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
-{
-}
+    where
+        M: Message + Send,
+        M::Result: Send,
+{}
 
 impl<M> Hash for Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.tx.hash().hash(state)
@@ -356,9 +355,9 @@ where
 }
 
 impl<M> fmt::Debug for Recipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "Recipient {{ /* omitted */ }}")
@@ -367,17 +366,17 @@ where
 
 /// A weakly referenced counterpart to `Recipient<M>`
 pub struct WeakRecipient<M: Message>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     wtx: Box<dyn WeakSender<M> + Sync>,
 }
 
 impl<M> fmt::Debug for WeakRecipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "WeakRecipient {{ /* omitted */ }}")
@@ -385,9 +384,9 @@ where
 }
 
 impl<M> Clone for WeakRecipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn clone(&self) -> Self {
         Self {
@@ -396,10 +395,18 @@ where
     }
 }
 
+impl<M> PartialEq for WeakRecipient<M>
+    where M: Message + Send,
+          M::Result: Send {
+    fn eq(&self, other: &Self) -> bool {
+       self.wtx.hash() == other.wtx.hash()
+    }
+}
+
 impl<M> From<Recipient<M>> for WeakRecipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     fn from(recipient: Recipient<M>) -> Self {
         recipient.downgrade()
@@ -407,9 +414,9 @@ where
 }
 
 impl<M> WeakRecipient<M>
-where
-    M: Message + Send,
-    M::Result: Send,
+    where
+        M: Message + Send,
+        M::Result: Send,
 {
     pub(crate) fn new(wtx: Box<dyn WeakSender<M> + Sync>) -> WeakRecipient<M> {
         WeakRecipient { wtx }
@@ -422,10 +429,10 @@ where
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<Addr<A>> for WeakRecipient<M>
-where
-    A: Handler<M>,
-    M::Result: Send,
-    A::Context: ToEnvelope<A, M>,
+    where
+        A: Handler<M>,
+        M::Result: Send,
+        A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: Addr<A>) -> WeakRecipient<M> {
         addr.downgrade().recipient()
@@ -433,10 +440,10 @@ where
 }
 
 impl<A: Actor, M: Message + Send + 'static> From<WeakAddr<A>> for WeakRecipient<M>
-where
-    A: Handler<M>,
-    M::Result: Send,
-    A::Context: ToEnvelope<A, M>,
+    where
+        A: Handler<M>,
+        M::Result: Send,
+        A::Context: ToEnvelope<A, M>,
 {
     fn from(addr: WeakAddr<A>) -> WeakRecipient<M> {
         WeakRecipient::new(Box::new(addr.wtx))
@@ -461,6 +468,7 @@ mod tests {
     }
 
     pub struct SetCounter(usize);
+
     impl Message for SetCounter {
         type Result = ();
     }

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -273,15 +273,29 @@ fn test_weak_addr_partial_equality() {
 
         // if this stops compiling this means that Add::downgrade
         // now takes self by value and we must clone before downgrading
+
         assert!(actor1.connected(), "actor 1 must be alive");
         assert!(actor2.connected(), "actor 2 must be alive");
+        // the assertions we want to hold for partial equality of weak actor addresses
+        // these assertions must hold whether one or both of the actors are connected or not
+        let check_equality_assertions = || {
+            assert_eq!(weak1, weak1);
+            assert_eq!(weak1, weak1_again);
+            assert_eq!(weak2, weak2);
 
-        assert_eq!(weak1, weak1);
-        assert_eq!(weak1, weak1_again);
-        assert_eq!(weak2, weak2);
+            assert_ne!(weak1, weak2);
+            assert_ne!(weak1_again, weak2);
+        };
+        check_equality_assertions();
 
-        assert_ne!(weak1, weak2);
-        assert_ne!(weak1_again, weak2);
+        // now drop one of the actors and make sure the same equality comparisons still hold
+        drop(actor1);
+        assert!(actor2.connected());
+        check_equality_assertions();
+
+        // and drop the second actor as well
+        drop(actor2);
+        check_equality_assertions();
     });
 }
 

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -224,7 +224,7 @@ fn test_weak_recipient_can_be_cloned() {
             pings, 2,
             "both the weak recipient and its clone must have sent a ping"
         );
-    })
+    });
 }
 
 #[test]
@@ -256,7 +256,33 @@ fn test_recipient_can_be_downgraded() {
             ping_count, 2,
             "weak recipients must not fail to send a message"
         );
-    })
+    });
+}
+
+#[test]
+fn test_weak_addr_partial_equality() {
+    let sys = System::new();
+
+    sys.block_on(async move {
+        let actor1 = MyActor3 {}.start();
+        let actor2 = MyActor3 {}.start();
+
+        let weak1 = actor1.downgrade();
+        let weak1_again = actor1.downgrade();
+        let weak2 = actor2.downgrade();
+
+        // if this stops compiling this means that Add::downgrade
+        // now takes self by value and we must clone before downgrading
+        assert!(actor1.connected(), "actor 1 must be alive");
+        assert!(actor2.connected(), "actor 2 must be alive");
+
+        assert_eq!(weak1, weak1);
+        assert_eq!(weak1, weak1_again);
+        assert_eq!(weak2, weak2);
+
+        assert_ne!(weak1, weak2);
+        assert_ne!(weak1_again, weak2);
+    });
 }
 
 #[test]

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -287,6 +287,13 @@ fn test_weak_addr_partial_equality() {
             assert_ne!(weak1_again, weak2);
         };
         check_equality_assertions();
+        // make sure that the same results apply when upgrading weak addr to addr and
+        // comparing strong addresses so the results are intuitive and consistent
+        assert_eq!(weak1.upgrade().unwrap(), weak1.upgrade().unwrap());
+        assert_eq!(weak1.upgrade().unwrap(), weak1_again.upgrade().unwrap());
+        assert_eq!(weak2.upgrade().unwrap(), weak2.upgrade().unwrap());
+        assert_ne!(weak1.upgrade().unwrap(), weak2.upgrade().unwrap());
+        assert_ne!(weak1_again.upgrade().unwrap(), weak2.upgrade().unwrap());
 
         // now drop one of the actors and make sure the same equality comparisons still hold
         drop(actor1);


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
We can now compare weak addresses for equality directly. In case two weak addresses `w1` and `w2` can both be upgraded, comparing `w1 == w2` will produce the same result as `w1.upgrade().unwrap() == w2.upgrade().unwrap()`. The same is true for the negation. If the weak addresses cannot be upgraded, the result still makes sense intuitively because it will check whether the weak address points to the same underlying actor, even if the actor is already destroyed.

There are no breaking changes, because `PartialEq` and `Eq` have been added to `WeakAddr` and `WeakAddressSender` and nothing else has been removed or changed.

## Issues
Closes #523 