### PR TITLE
Derive `PartialEq` and `Eq` for `MailboxError`

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## Unreleased - 2021-xx-xx
 
+### Added
+
+- Derive `PartialEq` and `Eq` for `MailboxError`. [#527]
+
+[#527]: https://github.com/actix/actix/pull/527
 
 ## 0.13.0 - 2022-03-01
 ### Added

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -20,7 +20,7 @@ pub enum SendError<T> {
     Closed(T),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 /// The errors that can occur during the message delivery process.
 pub enum MailboxError {
     Closed,


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist

- [x] Tests for the changes have been added / updated. _(not necessary for this patch?)_
- [x] Documentation comments have been added / updated. _(not necessary for this patch?)_
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview

Derive the `PartialEq` and `Eq` traits for `MailboxError`. 
This is mainly a convenience change, it eases writing test cases with `assert_eq!`. Unless I am missing something there is no reason not to derive them.

