### PR TITLE
API Extensions for WeakAddr and WeakRecipient

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,7 +1,7 @@
 # CHANGES
 - Add `connected` associated functions to `WeakAddr` and `WeakRecipient` with same semantics as in `Addr` and `Recipient`
 - Implement missing conversion `From<Addr<A>>` for `WeakAddr<A>`
-- `WeakAddr` and `WeakRecipient` are not exposed as part of `prelude`
+- `WeakAddr` and `WeakRecipient` are now exposed as part of `prelude`
 ## Unreleased - 2021-xx-xx
 
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,6 @@
 # CHANGES
-- Add `connected` associated functions to `WeakAddr` and `WeakRecipient`
-- Implement conversion `From<Addr<A>>` for `WeakAddr<A>`
+- Add `connected` associated functions to `WeakAddr` and `WeakRecipient` with same semantics as in `Addr` and `Recipient`
+- Implement missing conversion `From<Addr<A>>` for `WeakAddr<A>`
 ## Unreleased - 2021-xx-xx
 
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,7 @@
 # CHANGES
 - Add `connected` associated functions to `WeakAddr` and `WeakRecipient` with same semantics as in `Addr` and `Recipient`
 - Implement missing conversion `From<Addr<A>>` for `WeakAddr<A>`
+- `WeakAddr` and `WeakRecipient` are not exposed as part of `prelude`
 ## Unreleased - 2021-xx-xx
 
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,6 +1,6 @@
 # CHANGES
 - Add `connected` associated functions to `WeakAddr` and `WeakRecipient`
-- 
+- Implement conversion `From<Addr<A>>` for `WeakAddr<A>`
 ## Unreleased - 2021-xx-xx
 
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -1,5 +1,6 @@
 # CHANGES
-
+- Add `connected` associated functions to `WeakAddr` and `WeakRecipient`
+- 
 ## Unreleased - 2021-xx-xx
 
 

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -21,7 +21,7 @@ use tokio::sync::oneshot::{channel as oneshot_channel, Receiver as OneshotReceiv
 
 use crate::actor::Actor;
 use crate::handler::{Handler, Message};
-use crate::WeakAddr;
+
 
 use super::envelope::{Envelope, ToEnvelope};
 use super::queue::Queue;

--- a/actix/src/address/channel.rs
+++ b/actix/src/address/channel.rs
@@ -22,15 +22,14 @@ use tokio::sync::oneshot::{channel as oneshot_channel, Receiver as OneshotReceiv
 use crate::actor::Actor;
 use crate::handler::{Handler, Message};
 
-
 use super::envelope::{Envelope, ToEnvelope};
 use super::queue::Queue;
 use super::SendError;
 
 pub trait Sender<M>: Send
-    where
-        M::Result: Send,
-        M: Message + Send,
+where
+    M::Result: Send,
+    M: Message + Send,
 {
     fn do_send(&self, msg: M) -> Result<(), SendError<M>>;
 
@@ -49,10 +48,10 @@ pub trait Sender<M>: Send
 }
 
 impl<S, M> Sender<M> for Box<S>
-    where
-        S: Sender<M> + ?Sized,
-        M::Result: Send,
-        M: Message + Send,
+where
+    S: Sender<M> + ?Sized,
+    M::Result: Send,
+    M: Message + Send,
 {
     fn do_send(&self, msg: M) -> Result<(), SendError<M>> {
         (**self).do_send(msg)
@@ -84,9 +83,9 @@ impl<S, M> Sender<M> for Box<S>
 }
 
 pub trait WeakSender<M>: Send
-    where
-        M::Result: Send,
-        M: Message + Send,
+where
+    M::Result: Send,
+    M: Message + Send,
 {
     /// Attempts to upgrade a `WeakAddressSender<A>` to a [`Sender<M>`]
     ///
@@ -135,11 +134,14 @@ pub struct WeakAddressSender<A: Actor> {
 impl<A: Actor> WeakAddressSender<A> {
     /// Returns true iff the actor is still alive.
     pub fn connected(&self) -> bool {
-        self.inner.upgrade().map(|inner| {
-            let curr = inner.state.load(SeqCst);
-           let state = decode_state(curr);
-            state.is_open
-        }).unwrap_or(false)
+        self.inner
+            .upgrade()
+            .map(|inner| {
+                let curr = inner.state.load(SeqCst);
+                let state = decode_state(curr);
+                state.is_open
+            })
+            .unwrap_or(false)
     }
 }
 
@@ -315,11 +317,11 @@ impl<A: Actor> AddressSender<A> {
     ///
     /// This function must be called from inside of a task.
     pub fn send<M>(&self, msg: M) -> Result<OneshotReceiver<M::Result>, SendError<M>>
-        where
-            A: Handler<M>,
-            A::Context: ToEnvelope<A, M>,
-            M::Result: Send,
-            M: Message + Send,
+    where
+        A: Handler<M>,
+        A::Context: ToEnvelope<A, M>,
+        M::Result: Send,
+        M: Message + Send,
     {
         // If the sender is currently blocked, reject the message
         if !self.poll_unparked(false, None).is_ready() {
@@ -355,11 +357,11 @@ impl<A: Actor> AddressSender<A> {
 
     /// Attempts to send a message on this `Sender<A>` without blocking.
     pub fn try_send<M>(&self, msg: M, park: bool) -> Result<(), SendError<M>>
-        where
-            A: Handler<M>,
-            <A as Actor>::Context: ToEnvelope<A, M>,
-            M::Result: Send,
-            M: Message + Send + 'static,
+    where
+        A: Handler<M>,
+        <A as Actor>::Context: ToEnvelope<A, M>,
+        M::Result: Send,
+        M: Message + Send + 'static,
     {
         // If the sender is currently blocked, reject the message
         if !self.poll_unparked(false, None).is_ready() {
@@ -387,11 +389,11 @@ impl<A: Actor> AddressSender<A> {
     ///
     /// This function does not park current task.
     pub fn do_send<M>(&self, msg: M) -> Result<(), SendError<M>>
-        where
-            A: Handler<M>,
-            <A as Actor>::Context: ToEnvelope<A, M>,
-            M::Result: Send,
-            M: Message + Send,
+    where
+        A: Handler<M>,
+        <A as Actor>::Context: ToEnvelope<A, M>,
+        M::Result: Send,
+        M: Message + Send,
     {
         if self.inc_num_messages().is_none() {
             Err(SendError::Closed(msg))
@@ -495,11 +497,11 @@ impl<A: Actor> AddressSender<A> {
 }
 
 impl<A, M> Sender<M> for AddressSender<A>
-    where
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M::Result: Send,
-        M: Message + Send + 'static,
+where
+    A: Handler<M>,
+    A::Context: ToEnvelope<A, M>,
+    M::Result: Send,
+    M: Message + Send + 'static,
 {
     fn do_send(&self, msg: M) -> Result<(), SendError<M>> {
         self.do_send(msg)
@@ -601,16 +603,14 @@ impl<A: Actor> WeakAddressSender<A> {
     pub fn upgrade(&self) -> Option<AddressSender<A>> {
         Weak::upgrade(&self.inner).map(|inner| AddressSenderProducer { inner }.sender())
     }
-
-
 }
 
 impl<A, M> WeakSender<M> for WeakAddressSender<A>
-    where
-        A: Handler<M>,
-        A::Context: ToEnvelope<A, M>,
-        M::Result: Send,
-        M: Message + Send + 'static,
+where
+    A: Handler<M>,
+    A::Context: ToEnvelope<A, M>,
+    M::Result: Send,
+    M: Message + Send + 'static,
 {
     fn upgrade(&self) -> Option<Box<dyn Sender<M> + Sync>> {
         if let Some(inner) = WeakAddressSender::upgrade(self) {
@@ -625,7 +625,9 @@ impl<A, M> WeakSender<M> for WeakAddressSender<A>
     }
 
     fn connected(&self) -> bool {
-        WeakAddressSender::upgrade(self).map(|inner| inner.connected()).unwrap_or(false)
+        WeakAddressSender::upgrade(self)
+            .map(|inner| inner.connected())
+            .unwrap_or(false)
     }
 }
 

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -1,7 +1,6 @@
 use std::hash::{Hash, Hasher};
 use std::{error, fmt};
 
-
 pub(crate) mod channel;
 mod envelope;
 mod message;
@@ -221,7 +220,6 @@ impl<A: Actor> WeakAddr<A> {
     pub fn connected(&self) -> bool {
         self.wtx.connected()
     }
-
 }
 
 impl<A: Actor> Clone for WeakAddr<A> {

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 use std::{error, fmt};
+use std::rc::Weak;
 
 pub(crate) mod channel;
 mod envelope;
@@ -246,6 +247,14 @@ impl<A: Actor> PartialEq for WeakAddr<A> {
 }
 
 impl<A: Actor> std::cmp::Eq for WeakAddr<A> {}
+
+impl<A: Actor> From<Addr<A>> for WeakAddr<A> {
+    fn from(addr: Addr<A>) -> Self {
+        WeakAddr {
+            wtx: addr.tx.downgrade(),
+        }
+    }
+}
 
 /// The [`Recipient`] type allows to send one specific message to an actor.
 ///

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -73,7 +73,6 @@ impl<T> fmt::Display for SendError<T> {
 }
 
 /// The address of an actor.
-#[derive(Debug)]
 pub struct Addr<A: Actor> {
     tx: AddressSender<A>,
 }
@@ -179,8 +178,13 @@ impl<A: Actor> Hash for Addr<A> {
     }
 }
 
+impl<A: Actor> fmt::Debug for Addr<A> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Addr").field("tx", &self.tx).finish()
+    }
+}
+
 /// A weakly referenced counterpart to `Addr<A>`.
-#[derive(Debug)]
 pub struct WeakAddr<A: Actor> {
     wtx: WeakAddressSender<A>,
 }
@@ -222,12 +226,18 @@ impl<A: Actor> Clone for WeakAddr<A> {
     }
 }
 
-/// The [`Recipient`] type allows to send one specific message to an
-/// actor.
+impl<A: Actor> fmt::Debug for WeakAddr<A> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("WeakAddr")
+            .field("wtx", &self.wtx)
+            .finish()
+    }
+}
+
+/// The [`Recipient`] type allows to send one specific message to an actor.
 ///
-/// You can get a recipient using the `Addr::recipient()` method. It
-/// is possible to use the `Clone::clone()` method to get a cloned
-/// recipient.
+/// You can get a recipient using the `Addr::recipient()` method. It is possible
+/// to use the `Clone::clone()` method to get a cloned recipient.
 pub struct Recipient<M: Message>
 where
     M: Message + Send,

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -1,6 +1,6 @@
 use std::hash::{Hash, Hasher};
 use std::{error, fmt};
-use std::rc::Weak;
+
 
 pub(crate) mod channel;
 mod envelope;

--- a/actix/src/address/mod.rs
+++ b/actix/src/address/mod.rs
@@ -215,6 +215,12 @@ impl<A: Actor> WeakAddr<A> {
     {
         self.into()
     }
+
+    /// Returns true iff the actor is still alive.
+    pub fn connected(&self) -> bool {
+        self.wtx.connected()
+    }
+
 }
 
 impl<A: Actor> Clone for WeakAddr<A> {
@@ -418,6 +424,11 @@ where
     /// Attempts to upgrade the `WeakRecipient<M>` pointer to an `Recipient<M>`, similar to `WeakAddr<A>`
     pub fn upgrade(&self) -> Option<Recipient<M>> {
         self.wtx.upgrade().map(Recipient::new)
+    }
+
+    /// Returns true if the recipient is still alive
+    pub fn connected(&self) -> bool {
+        self.wtx.connected()
     }
 }
 

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -102,7 +102,8 @@ pub mod prelude {
         Actor, ActorContext, ActorState, AsyncContext, Running, SpawnHandle, Supervised,
     };
     pub use crate::address::{
-        Addr, MailboxError, Recipient, RecipientRequest, Request, SendError,
+        Addr, MailboxError, Recipient, RecipientRequest, Request, SendError, WeakAddr,
+        WeakRecipient,
     };
     pub use crate::context::{Context, ContextFutureSpawner};
     pub use crate::fut::{
@@ -142,9 +143,11 @@ pub mod dev {
     pub use crate::prelude::*;
 
     pub use crate::address::{Envelope, EnvelopeProxy, RecipientRequest, Request, ToEnvelope};
+
     pub mod channel {
         pub use crate::address::channel::{channel, AddressReceiver, AddressSender};
     }
+
     pub use crate::contextimpl::{AsyncContextParts, ContextFut, ContextParts};
     pub use crate::handler::{MessageResponse, OneshotSender};
     pub use crate::mailbox::Mailbox;

--- a/actix/tests/test_address.rs
+++ b/actix/tests/test_address.rs
@@ -8,7 +8,6 @@ use actix_rt::time::sleep;
 use actix::prelude::*;
 use actix::{WeakAddr, WeakRecipient};
 
-
 #[derive(Debug)]
 struct Ping(usize);
 
@@ -566,13 +565,34 @@ fn test_weak_conversions() {
         let weak_addr_from_addr = WeakAddr::from(addr.clone());
 
         let weak_recipient_from_addr = WeakRecipient::<Ping>::from(addr.clone());
-        let weak_recipient_from_weak_addr = WeakRecipient::<Ping>::from(weak_addr_from_addr.clone());
+        let weak_recipient_from_weak_addr =
+            WeakRecipient::<Ping>::from(weak_addr_from_addr.clone());
         let weak_recipient_from_recipient = WeakRecipient::from(recipient.clone());
 
-        weak_addr_from_addr.upgrade().unwrap().send(Ping(1)).await.unwrap();
-        weak_recipient_from_addr.upgrade().unwrap().send(Ping(1)).await.unwrap();
-        weak_recipient_from_weak_addr.upgrade().unwrap().send(Ping(1)).await.unwrap();
-        weak_recipient_from_recipient.upgrade().unwrap().send(Ping(1)).await.unwrap();
+        weak_addr_from_addr
+            .upgrade()
+            .unwrap()
+            .send(Ping(1))
+            .await
+            .unwrap();
+        weak_recipient_from_addr
+            .upgrade()
+            .unwrap()
+            .send(Ping(1))
+            .await
+            .unwrap();
+        weak_recipient_from_weak_addr
+            .upgrade()
+            .unwrap()
+            .send(Ping(1))
+            .await
+            .unwrap();
+        weak_recipient_from_recipient
+            .upgrade()
+            .unwrap()
+            .send(Ping(1))
+            .await
+            .unwrap();
 
         let pings = addr.send(CountPings).await.unwrap();
         assert_eq!(pings, 4);
@@ -583,7 +603,6 @@ fn test_weak_conversions() {
 // test that the connected methods for weak addresses and recipients work with the same
 // semantics as the connected methods for normal addresses and recipients
 fn test_connected_for_weak_addr_and_recipient() {
-
     System::new().block_on(async move {
         let addr = PingCounterActor::start_default();
         let recipient = addr.clone().recipient::<Ping>();


### PR DESCRIPTION
## PR Type
Feature

## PR Checklist
Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
Both `WeakAddr` and `WeakRecipient` now offer a `connected` associated function with the same behavior as their strong counterparts. Furthermore a conversion trait `From<Addr<A>>` for `WeakAddr<A>` was added so that the conversions between weak / strong addresses and weak / strong recipients now all just work.

**(Unlikely) Breaking Change** the `WeakSender` trait was extended by a `connected` associated function. It is unlikely that downstream crates implement this trait themselves, so this will probably not break any code.