### PR TITLE
Fix broken links in README.md

### DIFF
--- a/actix/README.md
+++ b/actix/README.md
@@ -93,8 +93,8 @@ implement the `started`, `stopping` and `stopped` methods of the Actor trait. `s
 when the actor starts and `stopping` when the actor finishes. Check the API docs
 for more information on [the actor lifecycle].
 
-[Actor trait]: [https://actix.github.io/actix/actix/trait.Actor.html]
-[the actor lifecycle]: [https://actix.github.io/actix/actix/trait.Actor.html#actor-lifecycle]
+[Actor trait]: https://actix.github.io/actix/actix/trait.Actor.html
+[the actor lifecycle]: https://actix.github.io/actix/actix/trait.Actor.html#actor-lifecycle
 
 ### Handle Messages
 


### PR DESCRIPTION
## PR Type
Other: Documentation Fix

## PR Checklist

Not Applicable

## Overview

Fixes two broken links in README.md by removing the square brackets around the URL. I found this because the links did work in VsCode preview of README.md. I then look at the README.md on github and noticed that the links didn't work on Safari, Chrome and Mozilla. After this change the links work on those and continue to work in the VsCode preview.

