### PR TITLE
Fix I am alive warnings

### DIFF
--- a/actix/README.md
+++ b/actix/README.md
@@ -65,25 +65,25 @@ In order to define an actor you need to define a struct and have it implement
 the [`Actor`](https://actix.github.io/actix/actix/trait.Actor.html) trait.
 
 ```rust
-use actix::{Actor, Addr, Context, System};
+use actix::{Actor, Context, System};
 
 struct MyActor;
 
 impl Actor for MyActor {
     type Context = Context<Self>;
 
-    fn started(&mut self, ctx: &mut Self::Context) {
+    fn started(&mut self, _ctx: &mut Self::Context) {
         println!("I am alive!");
         System::current().stop(); // <- stop system
     }
 }
 
 fn main() {
-    let mut system = System::new();
+    let system = System::new();
 
-    let addr = system.block_on(async { MyActor.start() });
+    let _addr = system.block_on(async { MyActor.start() });
 
-    system.run();
+    system.run().unwrap();
 }
 ```
 

--- a/actix/README.md
+++ b/actix/README.md
@@ -124,7 +124,7 @@ impl Actor for Calculator {
 impl Handler<Sum> for Calculator {
     type Result = usize; // <- Message response type
 
-    fn handle(&mut self, msg: Sum, ctx: &mut Context<Self>) -> Self::Result {
+    fn handle(&mut self, msg: Sum, _ctx: &mut Context<Self>) -> Self::Result {
         msg.0 + msg.1
     }
 }

--- a/actix/README.md
+++ b/actix/README.md
@@ -196,11 +196,11 @@ impl Handler<Ping> for Game {
 }
 
 fn main() {
-    let mut system = System::new();
+    let system = System::new();
 
     // To get a Recipient object, we need to use a different builder method
     // which will allow postponing actor creation
-    let addr = system.block_on(async {
+    let _addr = system.block_on(async {
         Game::create(|ctx| {
             // now we can get an address of the first actor and create the second actor
             let addr = ctx.address();
@@ -224,7 +224,7 @@ fn main() {
         });
     });
 
-    system.run();
+    system.run().unwrap();
 }
 ```
 


### PR DESCRIPTION
## PR Type

Other: Doc change

## PR Checklist

Not applicable

## Overview

Prior to this change compiling this example generated the following warnings:
```
  $ cargo run
  warning: unused import: `Addr`
   --> i-am-alive/src/main.rs:1:20
    |
  1 | use actix::{Actor, Addr, Context, System};
    |                    ^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

  warning: unused variable: `addr`
    --> i-am-alive/src/main.rs:17:9
     |
  17 |     let addr = system.block_on(async { MyActor.start() });
     |         ^^^^ help: if this is intentional, prefix it with an underscore: `_addr`
     |
     = note: `#[warn(unused_variables)]` on by default

  warning: unused variable: `ctx`
   --> i-am-alive/src/main.rs:8:27
    |
  8 |     fn started(&mut self, ctx: &mut Self::Context) {
    |                           ^^^ help: if this is intentional, prefix it with an underscore: `_ctx`

  warning: variable does not need to be mutable
    --> i-am-alive/src/main.rs:15:9
     |
  15 |     let mut system = System::new();
     |         ----^^^^^^
     |         |
     |         help: remove this `mut`
     |
     = note: `#[warn(unused_mut)]` on by default

  warning: unused `Result` that must be used
    --> i-am-alive/src/main.rs:19:5
     |
  19 |     system.run();
     |     ^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_must_use)]` on by default
     = note: this `Result` may be an `Err` variant, which should be handled

  warning: `i-am-alive` (bin "i-am-alive") generated 5 warnings
      Finished dev [unoptimized + debuginfo] target(s) in 0.01s
       Running `/home/wink/prgs/rust/myrepos/expr-actix/target/debug/i-am-alive`
  I am alive!
```
After this change there are no warnings:
```
  $ cargo run
      Finished dev [unoptimized + debuginfo] target(s) in 0.01s
       Running `/home/wink/prgs/rust/myrepos/expr-actix/target/debug/i-am-alive`
  I am alive!
```
