### PR TITLE
fix: ensure at least once delivery on broker IssueAsync

### DIFF
--- a/actix-broker/CHANGES.md
+++ b/actix-broker/CHANGES.md
@@ -1,7 +1,7 @@
 # Changes
 
-## Unreleased - 2021-xx-xx
-
+## Unreleased - 2022-xx-xx
+- Fix at-least-once delivery guarantee for IssueAsync
 
 ## 0.4.2 - 2022-03-01
 - Add support for `actix` v0.13.

--- a/actix-broker/CHANGES.md
+++ b/actix-broker/CHANGES.md
@@ -1,7 +1,9 @@
 # Changes
 
 ## Unreleased - 2022-xx-xx
-- Fix at-least-once delivery guarantee for IssueAsync
+- Fix at-least-once delivery guarantee for IssueAsync. [#536]
+
+[#536]: https://github.com/actix/actix/pull/536
 
 ## 0.4.2 - 2022-03-01
 - Add support for `actix` v0.13.

--- a/actix-broker/src/broker.rs
+++ b/actix-broker/src/broker.rs
@@ -126,15 +126,22 @@ impl<T: 'static + Unpin, M: BrokerMsg> Handler<IssueAsync<M>> for Broker<T> {
     fn handle(&mut self, msg: IssueAsync<M>, _ctx: &mut Context<Self>) {
         trace!("Broker: Received IssueAsync");
         if let Some(mut subs) = self.take_subs::<M>() {
-            subs.drain(..)
-                .filter_map(|(id, s)| {
-                    if id == msg.1 || s.try_send(msg.0.clone()).is_ok() {
-                        Some((id, s))
-                    } else {
-                        None
+            subs.drain(..).for_each(|(id, s)| {
+                if id == msg.1 {
+                    self.add_sub::<M>(s, id);
+                } else {
+                    match s.try_send(msg.0.clone()) {
+                        Ok(_) => self.add_sub::<M>(s, id),
+                        Err(SendError::Full(_)) => {
+                            // Ensure that that the message is delivered even if the mailbox is full.
+                            // We do a try first to remove receiver that have closed their mailbox.
+                            s.do_send(msg.0.clone());
+                            self.add_sub::<M>(s, id);
+                        }
+                        Err(_) => (),
                     }
-                })
-                .for_each(|(id, s)| self.add_sub::<M>(s, id));
+                }
+            });
         }
         self.set_msg::<M>(msg.0);
     }

--- a/actix-broker/src/issue.rs
+++ b/actix-broker/src/issue.rs
@@ -14,6 +14,9 @@ where
     <Self as Actor>::Context: AsyncContext<Self>,
 {
     /// Asynchronously issue a message.
+    /// This bypasses the mailbox capacity, and  will always queue the message.
+    /// If the mailbox is closed, the message is silently dropped and the subscriber
+    /// is detached from the broker.
     fn issue_async<T: RegisteredBroker, M: BrokerMsg>(&self, msg: M) {
         let broker = T::get_broker();
         broker.do_send(IssueAsync(msg, TypeId::of::<Self>()));

--- a/actix-broker/tests/delivery.rs
+++ b/actix-broker/tests/delivery.rs
@@ -1,0 +1,65 @@
+extern crate actix;
+extern crate actix_broker;
+
+use actix::clock::sleep;
+use actix::prelude::*;
+use actix_broker::{Broker, BrokerSubscribe, SystemBroker};
+
+use std::time::Duration;
+
+#[derive(Clone, Message)]
+#[rtype(result = "()")]
+struct TestMessage;
+
+#[derive(Default)]
+struct TestActor {
+    count: u8,
+}
+
+impl Actor for TestActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, ctx: &mut Self::Context) {
+        self.subscribe_async::<SystemBroker, TestMessage>(ctx);
+    }
+}
+
+impl Handler<TestMessage> for TestActor {
+    type Result = AtomicResponse<Self, ()>;
+
+    fn handle(&mut self, _msg: TestMessage, _ctx: &mut Self::Context) -> Self::Result {
+        let first = self.count == 0;
+        let task = async move {
+            if first {
+                sleep(Duration::from_millis(500)).await;
+            }
+        }
+        .into_actor(self)
+        .map(|_, act, _ctx| {
+            act.count += 1;
+            if act.count == 51 {
+                System::current().stop();
+            }
+        })
+        .boxed_local();
+
+        AtomicResponse::new(task)
+    }
+}
+
+#[test]
+fn it_issues_async_on_full_mailbox() {
+    let sys = System::new();
+
+    sys.block_on(async {
+        let addr = TestActor::default().start();
+        sleep(Duration::from_millis(100)).await;
+        addr.try_send(TestMessage)
+            .expect("Unable to send base message");
+        for _ in 0..50 {
+            Broker::<SystemBroker>::issue_async(TestMessage);
+        }
+    });
+
+    sys.run().unwrap();
+}


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug fix


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->
While the broker API is really not great, it did offer the guarantee of at-least-once delivery previously on `issue_async`.
Since the `do_send` doesn't return a result anymore, it was changed to a `try_send` which dropped the message on mailbox full.

This PR catches this error and will enqueue the message using `do_send`. I kept the first `try_send` to detect closed mailbox and detach them from the broker (which was the previous behaviour).

Ideally the broker would follow the same API as the actor and have something like a `do_send`, `try_send` and `send` instead. But this is a larger change that is out of scope for the current fix.

<!-- If this PR fixes or closes an issue, reference it here. -->
Closes #534
