### PR TITLE
doc: update crate documentation in `lib.rs`

### DIFF
--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -18,7 +18,7 @@
 //! - Using Futures for asynchronous message handling
 //! - Actor supervision
 //! - Typed messages (No [`Any`](std::any::Any) type). Generic messages are allowed
-//! - Runs on stable Rust 1.40+
+//! - Runs on stable Rust 1.54+
 
 #![allow(clippy::needless_doctest_main)]
 #![deny(nonstandard_style, rust_2018_idioms)]

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ## Other Documentation
 //! - [User Guide](https://actix.rs/book/actix/)
-//! - [Community Chat on Gitter](https://gitter.im/actix/actix)
+//! - [Community Chat on Discord](https://discord.gg/NWpN5mmg3x)
 //!
 //! ## Features
 //! - Async/Sync actors

--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -19,9 +19,6 @@
 //! - Actor supervision
 //! - Typed messages (No [`Any`](std::any::Any) type). Generic messages are allowed
 //! - Runs on stable Rust 1.40+
-//!
-//! ## Package feature
-//! * `resolver` - enables DNS resolver actor; see [resolver](./actors/resolver/index.html) module
 
 #![allow(clippy::needless_doctest_main)]
 #![deny(nonstandard_style, rust_2018_idioms)]


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Documentation Update


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

The top level crate documentation hasn't been updated in a long time.

* Updated MSRV
* Changed link from Gitter to Discord (since the Gitter doesn't exist anymore(?))
* Removed reference to `resolver` actor.

The line [`#![allow(deprecated)]`](https://github.com/actix/actix/blob/11379baf04ed6598f799034796ac4d266c2c3a99/actix/src/lib.rs#L34-L35) should be removed as well, but it doesn't have anything to do with the documentation.

https://github.com/actix/actix/blob/11379baf04ed6598f799034796ac4d266c2c3a99/actix/src/lib.rs#L34-L35

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
