### PR TITLE
Update futures-util dependency

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,11 +6,8 @@
 - Derive `PartialEq` and `Eq` for `MailboxError`. [#527]
 - Minimum supported Rust version (MSRV) is now 1.57.
 
-### Changed
-- Update futures-util dependency. [#544]
-
 [#527]: https://github.com/actix/actix/pull/527
-[#544]: https://github.com/actix/actix/pull/544
+
 
 ## 0.13.0 - 2022-03-01
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,7 +6,11 @@
 - Derive `PartialEq` and `Eq` for `MailboxError`. [#527]
 - Minimum supported Rust version (MSRV) is now 1.57.
 
+### Changed
+- Update futures-util dependency. [#544]
+
 [#527]: https://github.com/actix/actix/pull/527
+[#544]: https://github.com/actix/actix/pull/544
 
 ## 0.13.0 - 2022-03-01
 ### Added

--- a/actix/Cargo.toml
+++ b/actix/Cargo.toml
@@ -35,10 +35,10 @@ actix_derive = { version = "0.6.0", optional = true }
 bitflags = "1.2"
 bytes = "1"
 crossbeam-channel = "0.5"
-futures-core = { version = "0.3.25", default-features = false }
-futures-sink = { version = "0.3.25", default-features = false }
-futures-task = { version = "0.3.25", default-features = false }
-futures-util = { version = "0.3.25", default-features = false }
+futures-core = { version = "0.3.17", default-features = false }
+futures-sink = { version = "0.3.17", default-features = false }
+futures-task = { version = "0.3.17", default-features = false }
+futures-util = { version = "0.3.17", default-features = false }
 log = "0.4"
 once_cell = "1.5"
 parking_lot = "0.12"
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 
 [dev-dependencies]
 doc-comment = "0.3"
-futures-util = { version = "0.3.25", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.17", default-features = false, features = ["alloc"] }
 
 [[example]]
 name = "fibonacci"

--- a/actix/Cargo.toml
+++ b/actix/Cargo.toml
@@ -35,10 +35,10 @@ actix_derive = { version = "0.6.0", optional = true }
 bitflags = "1.2"
 bytes = "1"
 crossbeam-channel = "0.5"
-futures-core = { version = "0.3.7", default-features = false }
-futures-sink = { version = "0.3.7", default-features = false }
-futures-task = { version = "0.3.7", default-features = false }
-futures-util = { version = "0.3.7", default-features = false }
+futures-core = { version = "0.3.25", default-features = false }
+futures-sink = { version = "0.3.25", default-features = false }
+futures-task = { version = "0.3.25", default-features = false }
+futures-util = { version = "0.3.25", default-features = false }
 log = "0.4"
 once_cell = "1.5"
 parking_lot = "0.12"
@@ -49,7 +49,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 
 [dev-dependencies]
 doc-comment = "0.3"
-futures-util = { version = "0.3.7", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.25", default-features = false, features = ["alloc"] }
 
 [[example]]
 name = "fibonacci"


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Other

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

futures-util v0.3.7 was already yanked. So update futures-util.
https://github.com/rust-lang/futures-rs/blob/master/CHANGELOG.md#037---2020-10-23
https://github.com/rust-lang/futures-rs/issues/2310

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
