### PR TITLE
fixed futures_util deprecation warnings

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,11 +6,7 @@
 - Derive `PartialEq` and `Eq` for `MailboxError`. [#527]
 - Minimum supported Rust version (MSRV) is now 1.57.
 
-### Changed
-- Fixed `futures_util::stream::FuturesOrdered::<Fut>::push` deprecation warnings
-
 [#527]: https://github.com/actix/actix/pull/527
-[#545]: https://github.com/actix/actix/pull/545
 
 ## 0.13.0 - 2022-03-01
 ### Added

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,7 +6,11 @@
 - Derive `PartialEq` and `Eq` for `MailboxError`. [#527]
 - Minimum supported Rust version (MSRV) is now 1.57.
 
+### Changed
+- Fixed `futures_util::stream::FuturesOrdered::<Fut>::push` deprecation warnings
+
 [#527]: https://github.com/actix/actix/pull/527
+[#545]: https://github.com/actix/actix/pull/545
 
 ## 0.13.0 - 2022-03-01
 ### Added

--- a/actix/tests/test_fut.rs
+++ b/actix/tests/test_fut.rs
@@ -53,8 +53,8 @@ impl Actor for MyStreamActor {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         let mut s = futures_util::stream::FuturesOrdered::new();
-        s.push(sleep(Duration::from_millis(20)));
-        s.push(sleep(Duration::from_millis(20)));
+        s.push_back(sleep(Duration::from_millis(20)));
+        s.push_back(sleep(Duration::from_millis(20)));
 
         s.into_actor(self)
             .timeout(Duration::from_millis(1))


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Refactor

## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt


## Overview
<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

This fixed following deprecation warnings:

```
$ cargo test
   Compiling actix v0.13.0 (/Users/yoshimin/src/github.com/actix/actix/actix)
warning: use of deprecated associated function `futures_util::stream::FuturesOrdered::<Fut>::push`: use `push_back` instead
  --> actix/tests/test_fut.rs:56:11
   |
56 |         s.push(sleep(Duration::from_millis(20)));
   |           ^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated associated function `futures_util::stream::FuturesOrdered::<Fut>::push`: use `push_back` instead
  --> actix/tests/test_fut.rs:57:11
   |
57 |         s.push(sleep(Duration::from_millis(20)));
   |           ^^^^

warning: `actix` (test "test_fut") generated 2 warnings
    Finished test [unoptimized + debuginfo] target(s) in 0.45s
     Running unittests src/lib.rs (target/debug/deps/actix-dbc6df3178f7cf90)
```

push_back was introduced by https://github.com/rust-lang/futures-rs/issues/2309

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
