### PR TITLE
Upgrade GHA workflows to remove deprecation warnings

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -20,38 +20,30 @@ jobs:
     runs-on: ${{ matrix.target.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target.triple }}
-          profile: minimal
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup install ${{ matrix.version }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.version }}-${{ matrix.target.triple }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.2.0
 
       - name: check minimal
-        uses: actions-rs/cargo@v1
-        with:
-          command: hack
-          args: --clean-per-run check --workspace --no-default-features
+        run: cargo hack --clean-per-run check --workspace --no-default-features
 
       - name: tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -v --workspace --all-features --no-fail-fast -- --nocapture
+        run: cargo test -v --workspace --all-features --no-fail-fast -- --nocapture
 
       - name: Clear the cargo caches
         run: |
-          cargo install cargo-cache --version 0.6.2 --no-default-features --features ci-autoclean
+          rustup override set stable
+          cargo install cargo-cache --version 0.8.3 --no-default-features --features ci-autoclean
           cargo-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,36 +23,27 @@ jobs:
     runs-on: ${{ matrix.target.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install ${{ matrix.version }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.version }}-${{ matrix.target.triple }}
-          profile: minimal
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup install ${{ matrix.version }}-${{ matrix.target.triple }}
+          rustup override set ${{ matrix.version }}-${{ matrix.target.triple }}
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
       - name: Generate Cargo.lock
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
       - name: Cache Dependencies
-        uses: Swatinem/rust-cache@v1.2.0
+        uses: Swatinem/rust-cache@v2.2.0
 
       - name: check minimal
-        uses: actions-rs/cargo@v1
-        with:
-          command: hack
-          args: --clean-per-run check --workspace --no-default-features
+        run: cargo hack --clean-per-run check --workspace --no-default-features
 
       - name: tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -v --workspace --all-features --no-fail-fast -- --nocapture
+        run: cargo test -v --workspace --all-features --no-fail-fast -- --nocapture
 
       # disable coverage for now
       # - name: Generate coverage file
@@ -74,5 +65,6 @@ jobs:
 
       - name: Clear the cargo caches
         run: |
-          cargo install cargo-cache --version 0.6.2 --no-default-features --features ci-autoclean
+          rustup override set stable
+          cargo install cargo-cache --version 0.8.3 --no-default-features --features ci-autoclean
           cargo-cache

--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -8,32 +8,29 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: rustfmt
+        run: |
+          rustup override set stable
+          rustup update nightly
+          rustup component add rustfmt
       - name: Check with rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          components: clippy
-          override: true
+        run: |
+          rustup override set stable
+          rustup update nightly
+          rustup component add clippy
       - name: Check with Clippy
-        uses: actions-rs/clippy-check@v1
+        uses: giraffate/clippy-action@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests --all-features
+          reporter: 'github-pr-review'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clippy_flags: --workspace --tests --all-features

--- a/.github/workflows/upload-doc.yml
+++ b/.github/workflows/upload-doc.yml
@@ -9,27 +9,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly-x86_64-unknown-linux-gnu
-          profile: minimal
-          override: true
+        run: |
+          rustup set profile minimal
+          rustup install nightly-x86_64-unknown-linux-gnu
+          rustup override set nightly
 
       - name: Build Docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --workspace --all-features --no-deps
+        run: cargo doc --workspace --all-features --no-deps
 
       - name: Tweak HTML
         run: echo '<meta http-equiv="refresh" content="0;url=actix/index.html">' > target/doc/index.html
 
+      # TODO(JohnTitor): deploy via GHA directly instead.
       - name: Deploy to GitHub Pages
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: target/doc
+          folder: target/doc


### PR DESCRIPTION
Signed-off-by: Yuki Okushi <jtitor@2k36.org>

## PR Type
Other


## PR Checklist
Check your PR fulfills the following:

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt


## Overview

actions-rs is currently unmaintained and most actions can be replaced by just using pre-installed rustup and invoking Cargo. One pain is AFAIK there's no great and popular alternative to clippy-check, I've selected https://github.com/giraffate/clippy-action as it has some nice features.
