### PR TITLE
Change to DeferredWorkResult in ActorFuture docs

### DIFF
--- a/actix/src/fut/future/mod.rs
+++ b/actix/src/fut/future/mod.rs
@@ -80,7 +80,7 @@ mod timeout;
 ///
 /// impl Handler<DeferredWork> for OriginalActor {
 ///     // Notice the `Response` is an `ActorFuture`-ized version of `Self::Message::Result`.
-///     type Result = ResponseActFuture<Self, Result<OriginalActorResponse, MessageError>>;
+///     type Result = ResponseActFuture<Self, DeferredWorkResult>;
 ///
 ///     fn handle(&mut self, _msg: DeferredWork, _ctx: &mut Context<Self>) -> Self::Result {
 ///         // this creates a `Future` representing the `.send` and subsequent `Result` from


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type
<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Docs


## PR Checklist
Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] ~A changelog entry has been made for the appropriate packages.~
- [x] Format code with the latest stable rustfmt


## Overview

In reading [the ActorFuture docs](https://docs.rs/actix/0.13.0/actix/fut/future/trait.ActorFuture.html), I came across the following code:


```rust
// The response type returned by the actor future
type OriginalActorResponse = ();
// The error type returned by the actor future
type MessageError = ();
// This is the needed result for the DeferredWork message
// It's a result that combine both Response and Error from the future response.
type DeferredWorkResult = Result<OriginalActorResponse, MessageError>;

impl Handler<DeferredWork> for OriginalActor {
    // Notice the `Response` is an `ActorFuture`-ized version of `Self::Message::Result`.
    type Result = ResponseActFuture<Self, Result<OriginalActorResponse, MessageError>>;

...
```

While trying to understand it, I noticed that the Result type mimicked what the `DeferredWorkResult` was doing. I swapped it out, since I got a bit confused on why it was there otherwise. I could be missing why it was done a different way though. The updated code is:

```rust
impl Handler<DeferredWork> for OriginalActor {
    // Notice the `Response` is an `ActorFuture`-ized version of `Self::Message::Result`.
    type Result = ResponseActFuture<Self, DeferredWorkResult>;

...
```