### PR TITLE
Add test for and fix issue with SinkWrite not sending items in buffer

### DIFF
--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -57,9 +57,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1.5.0
-        # temp: unpin once https://github.com/rust-lang/rust/issues/113152 is fixed
         with:
-          toolchain: nightly-2023-06-28
+          toolchain: nightly-2023-08-25
 
       - uses: taiki-e/cache-cargo-install-action@v1.2.1
         with:

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,6 +6,7 @@
 
 - Add `SyncArbiter::start_with_thread_builder()`.
 - Derive `PartialEq` and `Eq` for `MailboxError`.
+- Fix SinkWrite not sending all messages in the buffer sometimes.
 - Minimum supported Rust version (MSRV) is now 1.68.
 
 ## 0.13.0 - 2022-03-01

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -6,8 +6,11 @@
 
 - Add `SyncArbiter::start_with_thread_builder()`.
 - Derive `PartialEq` and `Eq` for `MailboxError`.
-- Fix SinkWrite not sending all messages in the buffer sometimes.
 - Minimum supported Rust version (MSRV) is now 1.68.
+
+### Fixed
+
+- Fix SinkWrite not sending all messages in the buffer sometimes.
 
 ## 0.13.0 - 2022-03-01
 


### PR DESCRIPTION
<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix 

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [X] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [X] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt

## Overview

<!-- Describe the current and new behavior. -->
Currently, SinkWriteFuture only sends the first item in the buffer when polled. If the underlying Sink is Ready, and doesn't trigger the waker, and no further items are written to the SinkWrite, then the other items in the buffer are never send at all, since poll isn't called again because the task of the context isn't woken.

This can be seen in the test I added, which hangs without my fix: The Sink there doesn't block (is ready) when the messages are single bytes, so only the first byte is received on the other side of the channel. The second await hangs forever.

The fix is to simply loop and try to send all items in the buffer, until either the buffer is empty or the underlying Sink isn't ready anymore.

<!-- Emphasize any breaking changes. -->
This fix doesn't cause any breaking changes.

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
