### PR TITLE
docs: fix broken link

### DIFF
--- a/actix/src/lib.rs
+++ b/actix/src/lib.rs
@@ -9,7 +9,7 @@
 //! messages.
 //!
 //! ## Other Documentation
-//! - [User Guide](https://actix.rs/book/actix/)
+//! - [User Guide](https://actix.rs/docs/actix)
 //! - [Community Chat on Discord](https://discord.gg/NWpN5mmg3x)
 //!
 //! ## Features


### PR DESCRIPTION
https://actix.rs/book/actix is 404. I believe https://actix.rs/docs/actix is what we want here.