### PR TITLE
Expose `actix::ContextFut::restart` to public API

### DIFF
--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Minimum supported Rust version (MSRV) is now 1.68.
+- Expose `ContextFut::restart`.
 
 ## 0.13.1
 
@@ -12,7 +12,7 @@
 
 - Add `SyncArbiter::start_with_thread_builder()`.
 - Derive `PartialEq` and `Eq` for `MailboxError`.
-- Expose `ContextFut::restart`.
+- Minimum supported Rust version (MSRV) is now 1.68.
 
 ### Fixed
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Minimum supported Rust version (MSRV) is now 1.68.
+
 ## 0.13.1
 
 ### Added
@@ -9,7 +13,6 @@
 - Add `SyncArbiter::start_with_thread_builder()`.
 - Derive `PartialEq` and `Eq` for `MailboxError`.
 - Expose `ContextFut::restart`.
-- Minimum supported Rust version (MSRV) is now 1.68.
 
 ### Fixed
 

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -8,6 +8,7 @@
 
 - Add `SyncArbiter::start_with_thread_builder()`.
 - Derive `PartialEq` and `Eq` for `MailboxError`.
+- Expose `ContextFut::restart`.
 - Minimum supported Rust version (MSRV) is now 1.68.
 
 ### Fixed

--- a/actix/src/contextimpl.rs
+++ b/actix/src/contextimpl.rs
@@ -278,7 +278,7 @@ where
 
     /// Restart context. Cleanup all futures, except address queue.
     #[inline]
-    pub(crate) fn restart(&mut self) -> bool
+    pub fn restart(&mut self) -> bool
     where
         A: Supervised,
     {

--- a/actix/src/contextimpl.rs
+++ b/actix/src/contextimpl.rs
@@ -173,7 +173,10 @@ where
         Addr::new(self.addr.sender())
     }
 
-    /// Restart context. Cleanup all futures, except address queue.
+    /// Restarts the [`AsyncContext`] of this [`ContextParts`] by:
+    /// - canceling all the [`ActorFuture`]s spawned by [`ContextParts::spawn`];
+    /// - clearing the [`ContextParts::wait`] queue;
+    /// - forcing the [`Actor`] state to [`ActorState::Running`].
     #[inline]
     pub(crate) fn restart(&mut self) {
         self.flags = ContextFlags::RUNNING;
@@ -276,7 +279,16 @@ where
         }
     }
 
-    /// Restart context. Cleanup all futures, except address queue.
+    /// Restarts the [`AsyncContext`] of this [`ContextFut`] by:
+    /// - canceling all the [`ActorFuture`]s spawned by the [`AsyncContext`];
+    /// - clearing the [`ActorFuture`] await queue of the [`AsyncContext`];
+    /// - forcing the [`Actor`] state to [`ActorState::Running`];
+    /// - calling [`Supervised::restarting`] on the [`Actor`].
+    ///
+    /// and returns whether the [`Context`] was restarted. Restart may fail
+    /// only if the [`Mailbox`] is not [`connected`].
+    ///
+    /// [`connected`]: Mailbox::connected
     #[inline]
     pub fn restart(&mut self) -> bool
     where

--- a/actix/src/contextimpl.rs
+++ b/actix/src/contextimpl.rs
@@ -173,10 +173,10 @@ where
         Addr::new(self.addr.sender())
     }
 
-    /// Restarts the [`AsyncContext`] of this [`ContextParts`] by:
-    /// - canceling all the [`ActorFuture`]s spawned by [`ContextParts::spawn`];
+    /// Restarts this [`ContextParts`] by:
+    /// - canceling all the [`ActorFuture`]s spawned via [`ContextParts::spawn`];
     /// - clearing the [`ContextParts::wait`] queue;
-    /// - forcing the [`Actor`] state to [`ActorState::Running`].
+    /// - changing the [`Actor`] state to [`ActorState::Running`].
     #[inline]
     pub(crate) fn restart(&mut self) {
         self.flags = ContextFlags::RUNNING;
@@ -279,14 +279,16 @@ where
         }
     }
 
-    /// Restarts the [`AsyncContext`] of this [`ContextFut`] by:
+    /// Restarts the [`AsyncContext`] of this [`ContextFut`] returning whether the [`Context`] was
+    /// restarted.
+    ///
+    /// Restarting the [`Context`] means:
     /// - canceling all the [`ActorFuture`]s spawned by the [`AsyncContext`];
     /// - clearing the [`ActorFuture`] await queue of the [`AsyncContext`];
-    /// - forcing the [`Actor`] state to [`ActorState::Running`];
+    /// - changing the [`Actor`] state to [`ActorState::Running`];
     /// - calling [`Supervised::restarting`] on the [`Actor`].
     ///
-    /// and returns whether the [`Context`] was restarted. Restart may fail
-    /// only if the [`Mailbox`] is not [`connected`].
+    /// Restart may fail only if the [`Mailbox`] is not [`connected`].
     ///
     /// [`connected`]: Mailbox::connected
     #[inline]

--- a/actix/tests/test_context.rs
+++ b/actix/tests/test_context.rs
@@ -560,3 +560,100 @@ mod scheduled_task_is_cancelled_properly {
         sys.run().unwrap();
     }
 }
+
+mod restart {
+    use std::{
+        future::{poll_fn, Future},
+        rc::Rc,
+        sync::atomic::AtomicBool,
+    };
+
+    use super::*;
+
+    struct TestFuture(Rc<AtomicBool>);
+
+    impl TestFuture {
+        fn new(state: Rc<AtomicBool>) -> Self {
+            state.store(true, Ordering::Relaxed);
+            Self(state)
+        }
+    }
+
+    impl Future for TestFuture {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _: &mut StdContext<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for TestFuture {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Relaxed);
+        }
+    }
+
+    enum TestCase {
+        Spawn(Rc<AtomicBool>),
+        Wait(Rc<AtomicBool>),
+    }
+
+    struct TestActor(TestCase);
+
+    impl Actor for TestActor {
+        type Context = Context<Self>;
+
+        fn started(&mut self, ctx: &mut Self::Context) {
+            match &self.0 {
+                TestCase::Spawn(state) => {
+                    ctx.spawn(TestFuture::new(Rc::clone(state)).into_actor(self));
+                }
+                TestCase::Wait(state) => {
+                    ctx.wait(TestFuture::new(Rc::clone(state)).into_actor(self));
+                }
+            }
+            ctx.stop();
+        }
+    }
+
+    impl Supervised for TestActor {
+        fn restarting(&mut self, ctx: &mut Self::Context) {
+            assert_eq!(ctx.state(), ActorState::Running);
+        }
+    }
+
+    #[test]
+    fn cancels_spawned_futures() {
+        let state = Rc::new(AtomicBool::new(false));
+        let case = TestCase::Spawn(state.clone());
+
+        let ctx = Context::new();
+        let _addr = ctx.address();
+        let mut fut = ctx.into_future(TestActor(case));
+        System::new().block_on(poll_fn(|cx| {
+            assert_eq!(Pin::new(&mut fut).poll(cx), Poll::Ready(()));
+            assert!(state.load(Ordering::Relaxed));
+            fut.restart();
+            assert!(!state.load(Ordering::Relaxed));
+            assert_eq!(Pin::new(&mut fut).poll(cx), Poll::Ready(()));
+            Poll::Ready(())
+        }));
+    }
+
+    #[test]
+    fn clears_await_queue() {
+        let case = TestCase::Wait(Rc::new(AtomicBool::new(false)));
+
+        let ctx = Context::new();
+        let _addr = ctx.address();
+        let mut fut = ctx.into_future(TestActor(case));
+        System::new().block_on(poll_fn(|cx| {
+            assert_eq!(Pin::new(&mut fut).poll(cx), Poll::Ready(()));
+            assert!(fut.ctx().waiting());
+            fut.restart();
+            assert!(!fut.ctx().waiting());
+            assert_eq!(Pin::new(&mut fut).poll(cx), Poll::Ready(()));
+            Poll::Ready(())
+        }));
+    }
+}


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

### Motivation

Making possible to implement custom [`actix::Supervisor`] types.

### Problem

[`actix::Supervisor`] does not allow to shutdown an [`actix::Actor`] it supervising. In this case a custom [`actix::Supervisor`] should be implemented by the user to satisfy it needs (graceful shutdown of a supervised [`actix::Actor`] via `Supervisor::shutdown` in my case for example). But there is no way to implement a custom [`actix::Supervisor`] type because [`actix::ContextFut::restart`] is crate-local and can't be used in usercode.

### Solution

Make [`actix::ContextFut::restart`] public.

[`actix::Actor`]: https://github.com/actix/actix/blob/d7aab0a0f439679a570d08aaa6972ad8b60003de/actix/src/actor.rs#L75
[`actix::ContextFut::restart`]: https://github.com/actix/actix/blob/d7aab0a0f439679a570d08aaa6972ad8b60003de/actix/src/contextimpl.rs#L281
[`actix::Supervisor`]: https://github.com/actix/actix/blob/d7aab0a0f439679a570d08aaa6972ad8b60003de/actix/src/supervisor.rs#L74