### PR TITLE
Add run_interval_at to AsyncContext

### DIFF
--- a/.github/workflows/clippy-fmt.yml
+++ b/.github/workflows/clippy-fmt.yml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
         with:
-          toolchain: nightly-2023-08-25
+          toolchain: nightly-2024-06-07
 
       - uses: taiki-e/install-action@v2.24.1
         with:

--- a/actix/CHANGES.md
+++ b/actix/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add `AsyncContext::run_interval_at()` method.
+
 ## 0.13.3
 
 - No significant changes since `0.13.2`.

--- a/actix/src/actor.rs
+++ b/actix/src/actor.rs
@@ -456,18 +456,18 @@ where
         self.spawn(IntervalFunc::new(dur, f).finish())
     }
 
-    /// Spawns a job to execute the given closure once at the given
-    /// instant, then and periodically, at the specified fixed interval.
+    /// Spawns a periodic `task` function to begin executing at the given `start` time, and with the
+    /// given `interval` duration.
     fn run_interval_at<F>(
         &mut self,
         start: tokio::time::Instant,
-        dur: Duration,
-        f: F,
+        interval: Duration,
+        task: F,
     ) -> SpawnHandle
     where
         F: FnMut(&mut A, &mut A::Context) + 'static,
     {
-        self.spawn(IntervalFunc::new_at(start, dur, f).finish())
+        self.spawn(IntervalFunc::new_at(start, interval, task).finish())
     }
 }
 

--- a/actix/src/actor.rs
+++ b/actix/src/actor.rs
@@ -455,6 +455,20 @@ where
     {
         self.spawn(IntervalFunc::new(dur, f).finish())
     }
+
+    /// Spawns a job to execute the given closure once at the given
+    /// instant, then and periodically, at the specified fixed interval.
+    fn run_interval_at<F>(
+        &mut self,
+        start: tokio::time::Instant,
+        dur: Duration,
+        f: F,
+    ) -> SpawnHandle
+    where
+        F: FnMut(&mut A, &mut A::Context) + 'static,
+    {
+        self.spawn(IntervalFunc::new_at(start, dur, f).finish())
+    }
 }
 
 /// A handle to a spawned future.

--- a/actix/src/utils.rs
+++ b/actix/src/utils.rs
@@ -7,7 +7,10 @@ use std::{
 
 use futures_core::ready;
 use pin_project_lite::pin_project;
-use tokio::sync::oneshot;
+use tokio::{
+    sync::oneshot,
+    time::{sleep_until, Instant},
+};
 
 use crate::{
     actor::Actor,
@@ -191,6 +194,18 @@ impl<A: Actor> IntervalFunc<A> {
             f: Box::new(f),
             dur,
             timer: sleep(dur),
+        }
+    }
+
+    /// Creates a new `IntervalFunc` with the given interval duration, and designated start time
+    pub fn new_at<F>(start: Instant, dur: Duration, f: F) -> IntervalFunc<A>
+    where
+        F: FnMut(&mut A, &mut A::Context) + 'static,
+    {
+        Self {
+            f: Box::new(f),
+            dur,
+            timer: sleep_until(start),
         }
     }
 }


### PR DESCRIPTION
## PR Type

Feature

## PR Checklist

Check your PR fulfills the following:

- [x] Tests for the changes have been added / updated.
- [X] Documentation comments have been added / updated.
- [x] A changelog entry has been made for the appropriate packages.
- [X] Format code with the latest stable rustfmt

## Overview

Add the ability to run a closure in a Context with a given start time. Useful for instance if you want to run the closure immediately on an actor's creation, and subsequently at some interval. 

Naming convention follows tokio's naming convention for the same behavior i.e. `tokio::time::interval_at`