### PR TITLE
fix: Forward `poll_ready()` errors to the actor and possibly finish

### DIFF
--- a/actix/src/io.rs
+++ b/actix/src/io.rs
@@ -526,8 +526,11 @@ where
                         break;
                     }
                 }
-                Poll::Ready(Err(_err)) => {
-                    break;
+                Poll::Ready(Err(e)) => {
+                    if act.error(e, ctxt) == Running::Stop {
+                        act.finished(ctxt);
+                        return Poll::Ready(());
+                    }
                 }
                 Poll::Pending => {
                     break;


### PR DESCRIPTION
## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->

Bug Fix

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [ ] Format code with the latest stable rustfmt

## Overview

It's not generally supported to poll a `Sink` again after it returned an error anywhere, and e.g. `SinkMapErr` from the `futures` crate is simply panicking if this happens.

----

cc @gdesmott