### PR TITLE
fix(actix): avoid calling Actor::started during drop

### DIFF
--- a/actix/src/context_impl.rs
+++ b/actix/src/context_impl.rs
@@ -225,6 +225,10 @@ where
     A: Actor<Context = C>,
 {
     fn drop(&mut self) {
+        if !self.ctx.parts().flags.contains(ContextFlags::STARTED) {
+            return;
+        }
+
         if self.alive() {
             self.ctx.parts().stop();
             let waker = futures_task::noop_waker();

--- a/actix/tests/test_lifecycle.rs
+++ b/actix/tests/test_lifecycle.rs
@@ -285,3 +285,31 @@ fn test_stop_restore_after_stopping() {
     assert!(stopping.load(Ordering::Relaxed), "Not stopping");
     assert!(!stopped.load(Ordering::Relaxed), "Stopped");
 }
+
+#[test]
+fn test_drop_does_not_call_started() {
+    struct StartedFlagActor {
+        started: Arc<AtomicBool>,
+    }
+
+    impl Actor for StartedFlagActor {
+        type Context = Context<Self>;
+
+        fn started(&mut self, _: &mut Self::Context) {
+            self.started.store(true, Ordering::Relaxed);
+        }
+    }
+
+    let started = Arc::new(AtomicBool::new(false));
+
+    let fut = Context::new().into_future(StartedFlagActor {
+        started: Arc::clone(&started),
+    });
+
+    drop(fut);
+
+    assert!(
+        !started.load(Ordering::Relaxed),
+        "started() must not be called from Drop"
+    );
+}

--- a/actix/tests/test_lifecycle.rs
+++ b/actix/tests/test_lifecycle.rs
@@ -9,8 +9,7 @@ use std::{
 };
 
 use actix::prelude::*;
-use actix_rt::task::yield_now;
-use actix_rt::time::sleep;
+use actix_rt::{task::yield_now, time::sleep};
 use tokio::sync::oneshot::{channel, Sender};
 
 struct MyActor {

--- a/actix/tests/test_lifecycle.rs
+++ b/actix/tests/test_lifecycle.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use actix::prelude::*;
+use actix_rt::task::yield_now;
 use actix_rt::time::sleep;
 use tokio::sync::oneshot::{channel, Sender};
 
@@ -132,6 +133,8 @@ fn test_stop_after_drop_address() {
         }
         .start();
 
+        yield_now().await;
+
         actix_rt::spawn(async move {
             sleep(Duration::new(0, 100)).await;
             drop(addr);
@@ -163,6 +166,8 @@ fn test_stop_after_drop_sync_address() {
             restore_after_stop: false,
         }
         .start();
+
+        yield_now().await;
 
         actix_rt::spawn(async move {
             sleep(Duration::new(0, 100)).await;
@@ -237,6 +242,8 @@ fn test_stop() {
         }
         .start();
 
+        yield_now().await;
+
         actix_rt::spawn(async move {
             sleep(Duration::new(0, 100)).await;
             System::current().stop();
@@ -266,6 +273,8 @@ fn test_stop_restore_after_stopping() {
             restore_after_stop: true,
         }
         .start();
+
+        yield_now().await;
 
         actix_rt::spawn(async move {
             sleep(Duration::new(0, 100)).await;


### PR DESCRIPTION
When a System is dropped quickly, a ContextFut that was never polled could be
polled from Drop, which triggers Actor::started during runtime teardown. If started() schedules timers (eg. run_interval), Tokio time access can panic
with "there is no reactor running".
Skip drop-driven polling for never-started actors and add a regression test for
the quick-drop + run_interval case.

<!-- Thanks for considering contributing actix! -->
<!-- Please fill out the following to make our reviews easy. -->

## PR Type

<!-- What kind of change does this PR make? -->
<!-- Bug Fix / Feature / Refactor / Code Style / Other -->
Bug Fix

## PR Checklist

Check your PR fulfills the following:

<!-- For draft PRs check the boxes as you complete them. -->

- [x] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] A changelog entry has been made for the appropriate packages.
- [x] Format code with the latest stable rustfmt

## Overview

<!-- Describe the current and new behavior. -->
<!-- Emphasize any breaking changes. -->

<!-- If this PR fixes or closes an issue, reference it here. -->
<!-- Closes #000 -->
This PR fixes a panic that can occur when an Actix System is dropped very quickly after starting an actor that schedules timers in started() (eg. run_interval). During shutdown, Actix could end up invoking Actor::started() as part of drop cleanup, at a point where Tokio’s runtime/time driver is already being torn down, leading to the Tokio panic: “there is no reactor running”.
The change avoids running started() from drop-driven polling when the actor was never actually started (never polled), and includes a regression test covering the quick-drop scenario.
Closes #531